### PR TITLE
Retry Improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/replicate/pget
 
 go 1.19
 
-require github.com/dustin/go-humanize v1.0.1 // indirect
+require github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/tmthrgd/go-shm v0.0.0-20230106080200-1ec4c2ba35cf h1:zllFA+KeQ5EGsnMv8YtqBZQTEERX9UZkY+h2nKYY2JY=
-github.com/tmthrgd/go-shm v0.0.0-20230106080200-1ec4c2ba35cf/go.mod h1:sreX9Ec5xasLXkHjdpdrCXuYWgnB8a2T2ElLH+weMWY=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	retryDelayBaseline  = 100  // in milliseconds
-	retrySleepJitter    = 50   // in milliseconds (will add 0-50 additional milliseconds)
+	retrySleepJitter    = 500  // in milliseconds (will add 0-500 additional milliseconds)
 	retryMaxBackoffTime = 5000 // in milliseconds, we will not backoff further than 5 seconds
 	retryBackoffIncr    = 500  // in milliseconds, backoffFactor^retryNum * backoffIncr
 	retryBackoffFactor  = 2    // Base for POW()

--- a/main.go
+++ b/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -15,6 +17,14 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+)
+
+const (
+	retryDelayBaseline  = 100  // in milliseconds
+	retrySleepJitter    = 50   // in milliseconds (will add 0-50 additional milliseconds)
+	retryMaxBackoffTime = 5000 // in milliseconds, we will not backoff further than 5 seconds
+	retryBackoffIncr    = 500  // in milliseconds, backoffFactor^retryNum * backoffIncr
+	retryBackoffFactor  = 2    // Base for POW()
 )
 
 var _fileSize int64
@@ -34,7 +44,7 @@ func getRemoteFileSize(url string) (int64, error) {
 	return fileSize, nil
 }
 
-func downloadFileToBuffer(url string, concurrency int) (*bytes.Buffer, error) {
+func downloadFileToBuffer(url string, concurrency int, retries int) (*bytes.Buffer, error) {
 	fileSize, err := getRemoteFileSize(url)
 	if err != nil {
 		return nil, err
@@ -59,8 +69,8 @@ func downloadFileToBuffer(url string, concurrency int) (*bytes.Buffer, error) {
 		go func(start, end int64) {
 			defer wg.Done()
 
-			retries := 5
-			for retries > 0 {
+			success := false
+			for retryNum := 0; retryNum < retries; retryNum++ {
 				transport := http.DefaultTransport.(*http.Transport).Clone()
 				transport.DisableKeepAlives = true
 				client := &http.Client{
@@ -68,19 +78,30 @@ func downloadFileToBuffer(url string, concurrency int) (*bytes.Buffer, error) {
 				}
 
 				req, err := http.NewRequest("GET", url, nil)
+				sleepJitter := time.Duration(rand.Intn(retrySleepJitter))
+				sleepTime := time.Millisecond * (sleepJitter + retryDelayBaseline)
+				if retryNum > 0 {
+					// Exponential backoff
+					// 2^retryNum * retryBackoffIncr (in milliseconds)
+					backoffFactor := math.Pow(retryBackoffFactor, float64(retryNum))
+					backoffDuration := time.Duration(math.Min(backoffFactor*retryBackoffIncr, retryMaxBackoffTime))
+					sleepTime += (time.Millisecond * backoffDuration)
+				}
 				if err != nil {
+					// This needs to be a time.Duration to make everything happy
 					fmt.Printf("Error creating request: %v\n", err)
-					retries--
-					time.Sleep(time.Millisecond * 100) // wait 100 milliseconds before retrying
+					time.Sleep(sleepTime) // wait sleepTime milliseconds before retrying
 					continue
 				}
 				req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+				if retryNum > 0 {
+					req.Header.Set("Pget-Retry-Count", fmt.Sprintf("%d", retryNum))
+				}
 
 				resp, err := client.Do(req)
 				if err != nil {
 					fmt.Printf("Error executing request: %v\n", err)
-					retries--
-					time.Sleep(time.Millisecond * 100) // wait 100 milliseconds before retrying
+					time.Sleep(sleepTime) // wait sleepTime milliseconds before retrying
 					continue
 				}
 				defer resp.Body.Close()
@@ -88,22 +109,20 @@ func downloadFileToBuffer(url string, concurrency int) (*bytes.Buffer, error) {
 				n, err := io.ReadFull(resp.Body, data[start:end+1])
 				if err != nil && err != io.EOF {
 					fmt.Printf("Error reading response: %v\n", err)
-					retries--
-					time.Sleep(time.Millisecond * 100) // wait 100 milliseconds before retrying
+					time.Sleep(sleepTime) // wait sleepTime milliseconds before retrying
 					continue
 				}
 				if n != int(end-start+1) {
 					fmt.Printf("Downloaded %d bytes instead of %d\n", n, end-start+1)
-					retries--
-					time.Sleep(time.Millisecond * 100) // wait 100 milliseconds before retrying
+					time.Sleep(sleepTime) // wait sleepTime milliseconds before retrying
 					continue
 				}
+				success = true
 				break // if the download was successful, break out of the retry loop
 			}
 
-			if retries == 0 {
-				errc <- fmt.Errorf("failed to download after multiple retries")
-
+			if !success {
+				errc <- fmt.Errorf("failed to download after %d retries", retries)
 			}
 		}(start, end)
 	}
@@ -176,13 +195,14 @@ func extractTarFile(buffer *bytes.Buffer, destDir string) error {
 func main() {
 	// define flags
 	concurrency := flag.Int("c", runtime.GOMAXPROCS(0)*4, "concurrency level - default 4 * cores")
+	retries := flag.Int("r", 5, "Number of retries when attempting to retreive file")
 	extract := flag.Bool("x", false, "extract tar file")
 	flag.Parse()
 
 	// check required positional arguments
 	args := flag.Args()
 	if len(args) < 2 {
-		fmt.Println("Usage: pcurl <url> <dest> [-c concurrency] [-x]")
+		fmt.Println("Usage: pcurl <url> <dest> [-c concurrency] [-r max-retries] [-x]")
 		os.Exit(1)
 	}
 
@@ -195,7 +215,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	buffer, err := downloadFileToBuffer(url, *concurrency)
+	buffer, err := downloadFileToBuffer(url, *concurrency, *retries)
 	if err != nil {
 		fmt.Printf("Error downloading file: %v\n", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func downloadFileToBuffer(url string, concurrency int, retries int) (*bytes.Buff
 				}
 				req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
 				if retryNum > 0 {
-					req.Header.Set("Pget-Retry-Count", fmt.Sprintf("%d", retryNum))
+					req.Header.Set("Retry-Count", fmt.Sprintf("%d", retryNum))
 				}
 
 				resp, err := client.Do(req)

--- a/main.go
+++ b/main.go
@@ -22,7 +22,8 @@ import (
 const (
 	retryDelayBaseline  = 100  // in milliseconds
 	retrySleepJitter    = 500  // in milliseconds (will add 0-500 additional milliseconds)
-	retryMaxBackoffTime = 5000 // in milliseconds, we will not backoff further than 5 seconds
+
+	retryMaxBackoffTime = 3000 // in milliseconds, we will not backoff further than 3 seconds
 	retryBackoffIncr    = 500  // in milliseconds, backoffFactor^retryNum * backoffIncr
 	retryBackoffFactor  = 2    // Base for POW()
 )

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func downloadFileToBuffer(url string, concurrency int, retries int) (*bytes.Buff
 			defer wg.Done()
 
 			success := false
-			for retryNum := 0; retryNum < retries; retryNum++ {
+			for retryNum := 0; retryNum <= retries; retryNum++ {
 
 				if retryNum > 0 {
 					if verboseMode {

--- a/main.go
+++ b/main.go
@@ -105,15 +105,6 @@ func downloadFileToBuffer(url string, concurrency int, retries int) (*bytes.Buff
 				}
 
 				req, err := http.NewRequest("GET", url, nil)
-				sleepJitter := time.Duration(rand.Intn(retrySleepJitter))
-				sleepTime := time.Millisecond * (sleepJitter + retryDelayBaseline)
-				if retryNum > 0 {
-					// Exponential backoff
-					// 2^retryNum * retryBackoffIncr (in milliseconds)
-					backoffFactor := math.Pow(retryBackoffFactor, float64(retryNum))
-					backoffDuration := time.Duration(math.Min(backoffFactor*retryBackoffIncr, retryMaxBackoffTime))
-					sleepTime += (time.Millisecond * backoffDuration)
-				}
 				if err != nil {
 					// This needs to be a time.Duration to make everything happy
 					fmt.Printf("Error creating request: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -117,7 +117,6 @@ func downloadFileToBuffer(url string, concurrency int, retries int) (*bytes.Buff
 				if err != nil {
 					// This needs to be a time.Duration to make everything happy
 					fmt.Printf("Error creating request: %v\n", err)
-					time.Sleep(sleepTime) // wait sleepTime milliseconds before retrying
 					continue
 				}
 				req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
@@ -128,7 +127,6 @@ func downloadFileToBuffer(url string, concurrency int, retries int) (*bytes.Buff
 				resp, err := client.Do(req)
 				if err != nil {
 					fmt.Printf("Error executing request: %v\n", err)
-					time.Sleep(sleepTime) // wait sleepTime milliseconds before retrying
 					continue
 				}
 				defer resp.Body.Close()
@@ -136,12 +134,10 @@ func downloadFileToBuffer(url string, concurrency int, retries int) (*bytes.Buff
 				n, err := io.ReadFull(resp.Body, data[start:end+1])
 				if err != nil && err != io.EOF {
 					fmt.Printf("Error reading response: %v\n", err)
-					time.Sleep(sleepTime) // wait sleepTime milliseconds before retrying
 					continue
 				}
 				if n != int(end-start+1) {
 					fmt.Printf("Downloaded %d bytes instead of %d\n", n, end-start+1)
-					time.Sleep(sleepTime) // wait sleepTime milliseconds before retrying
 					continue
 				}
 				success = true


### PR DESCRIPTION
* Add sleep jitter for retries
* Add backoff with formula: 2^retryNum * 500ms, maximum 5000ms
* Add configurable (CLI) retries `-r` cli option
* Retries will include the `Pget-Retry-Count` header indicating the retry number