### PR TITLE
WIP: use less memory by downloading to sparse file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,12 @@ jobs:
         go-version-file: go.mod
     - run: script/build
     - uses: ncipollo/release-action@v1
-      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      if: github.ref_type=='tag' && !contains(github.ref_name, '-')
       with:
         artifacts: "pget"
+    - uses: ncipollo/release-action@v1
+      if: github.ref_type=='tag' && contains(github.ref_name, '-')
+      with:
+        artifacts: "pget"
+        prerelease: true
         

--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func main() {
 	// check required positional arguments
 	args := flag.Args()
 	if len(args) < 2 {
-		fmt.Println("Usage: pcurl <url> <dest> [-c concurrency] [-x]")
+		fmt.Println("Usage: pcurl [-c concurrency] [-x] <url> <dest>")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
pget has a problem that it needs to download everything into memory along each of the different parallel connections before finally saving everything to disk.  This has two consequences:

- pget needs to consume at least as much memory as the size of the downloaded file
- pget cannot begin writing to disk until all the bytes have been downloaded from source

I had a thought that we could precreate a sparse file of the correct length by using the os.Truncate(size) call.  Then each goroutine can write to different offsets within the same file, in parallel.

I tested this locally on macOS and I was able to download a 308MB file with pget's memory usage only reaching 26MB.

This commit is a WIP because I've commented out the untar stuff to keep the proof of concept simple.  We should restore (or deprecate?) that functionality before merging this.  We should also do more extensive performance testing.