### PR TITLE
Revert "WIP: use less memory by downloading to sparse file"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,7 @@ jobs:
         go-version-file: go.mod
     - run: script/build
     - uses: ncipollo/release-action@v1
-      if: github.ref_type=='tag' && !contains(github.ref_name, '-')
+      if: ${{ startsWith(github.ref, 'refs/tags') }}
       with:
         artifacts: "pget"
-    - uses: ncipollo/release-action@v1
-      if: github.ref_type=='tag' && contains(github.ref_name, '-')
-      with:
-        artifacts: "pget"
-        prerelease: true
         


### PR DESCRIPTION
Reverts replicate/pget#9

This makes `pget -x` much slower. We should investigate if we can fix that before committing to the sparse file implementation