### PR TITLE
Add instructions for installing with Homebrew and building from source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
   pull_request:
   workflow_dispatch:
 
@@ -22,13 +22,12 @@ jobs:
     name: Build
     runs-on: ubuntu-latest-8-cores
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v4
-      with:
-        go-version-file: go.mod
-    - run: script/build
-    - uses: ncipollo/release-action@v1
-      if: ${{ startsWith(github.ref, 'refs/tags') }}
-      with:
-        artifacts: "pget"
-        
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - run: make
+      - uses: ncipollo/release-action@v1
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        with:
+          artifacts: "pget"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,36 @@
-all:
-	CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o pget
+SHELL := /bin/bash
 
+DESTDIR ?=
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
+
+INSTALL := install -m 0755
+INSTALL_PROGRAM := $(INSTALL)
+
+GO := go
+GOOS := $(shell $(GO) env GOOS)
+GOARCH := $(shell $(GO) env GOARCH)
+
+default: all
+
+.PHONY: all
+all: pget
+
+pget:
+	CGO_ENABLED=0 $(GO) build -o $@ \
+		-ldflags '-extldflags "-static"' \
+		main.go
+
+.PHONY: install
+install: pget
+	$(INSTALL_PROGRAM) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) pget $(DESTDIR)$(BINDIR)/pget
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(BINDIR)/pget
+
+.PHONY: clean
 clean:
-	rm ./pget
+	$(GO) clean
+	rm -f replicate

--- a/README.md
+++ b/README.md
@@ -8,13 +8,31 @@ If the downloaded file is a tar archive, PGet can automatically extract the cont
 
 The efficiency of PGet's tar extraction lies in its approach to handling data. Instead of writing the downloaded tar file to disk and then reading it back into memory for extraction, PGet conducts the extraction directly from the in-memory download buffer. This method avoids unnecessary memory copies and disk I/O, leading to an increase in performance, especially when dealing with large tar files. This makes PGet not just a parallel downloader, but also an efficient file extractor, providing a streamlined solution for fetching and unpacking files.
 
+## Install
+
+If you're using macOS, you can install PGet with Homebrew:
+
+```console
+brew tap replicate/tap
+brew install pget
+```
+
+Or you can build from source and install it with these commands
+(requires Go 1.19 or later):
+
+```console
+make
+sudo make install
+```
+
+This builds a static binary that can work inside containers.
 
 ## Usage
-
 
     pget <url> <dest> [-c concurrency] [-x]
 
 Parameters
+
 - \<url\>: The URL of the file to download.
 - \<dest\>: The destination where the downloaded file will be stored.
 - -c concurrency: The number of concurrent downloads. Default is 4 times the number of cores.
@@ -32,18 +50,6 @@ PGet includes some error handling:
 
 1. If a download any chunks fails, it will automatically retry up to 5 times before giving up.
 2. If the downloaded file size does not match the expected size, it will also retry the download.
-
-## Dependencies
-
-PGet is built in Go and has no external dependencies beyond the Go standard library.
-
-## Building
-
-To build PGet, you need a working Go environment. You can build the binary with the following 
-
-    make
-
-This builds a static binary that can work inside containers.
 
 ## Future Improvements
 

--- a/script/build
+++ b/script/build
@@ -1,2 +1,0 @@
-#!/bin/sh
-CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o pget


### PR DESCRIPTION
This PR updates `Makefile` to follow the conventions used by Cog and the Replicate CLI, and updates the README and CI to use `make` for building the project exclusively. This PR also updates the README to provide instructions for [installing with Homebrew](https://github.com/replicate/homebrew-tap/pull/6) on macOS.