### PR TITLE
only follow redirect once

### DIFF
--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func main() {
 	dest := args[1]
 
 	// ensure dest does not exist
-	if !force || _, err := os.Stat(dest); !os.IsNotExist(err) {
+	if _, err := os.Stat(dest); !*force || !os.IsNotExist(err) {
 		fmt.Printf("Destination %s already exists\n", dest)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -217,6 +217,7 @@ func main() {
 	retries := flag.Int("r", 5, "Number of retries when attempting to retreive file")
 	extract := flag.Bool("x", false, "extract tar file")
 	verbose := flag.Bool("v", false, "verbose mode")
+	force := flag.Bool("f", false, "force download, overwriting existing file")
 	flag.Parse()
 
 	// check required positional arguments
@@ -230,7 +231,7 @@ func main() {
 	dest := args[1]
 
 	// ensure dest does not exist
-	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+	if !force || _, err := os.Stat(dest); !os.IsNotExist(err) {
 		fmt.Printf("Destination %s already exists\n", dest)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func getRemoteFileSize(url string) (string, int64, error) {
 		return "", int64(-1), err
 	}
 	defer resp.Body.Close()
-	trueUrl = resp.Request.URL.String()
+	trueUrl := resp.Request.URL.String()
 	if (trueUrl != url) {
 		fmt.Printf("Redirected to %s\n", trueUrl)
 	}


### PR DESCRIPTION
currently, each chunk has to wait for storagebouncer to do its thing and follows redirects. it's faster to follow the redirect once and use that url subsequently 

HEAD also needs retry logic but that's for another time