### PR TITLE
handle small files better

### DIFF
--- a/main.go
+++ b/main.go
@@ -250,6 +250,11 @@ func main() {
 		verboseMode = true
 	}
 
+    // allows us to see how many pget procs are running at a time
+	tmpFile := fmt.Sprintf("/tmp/.pget-%d", os.Getpid())
+	os.WriteFile(tmpFile, []byte(""), 0644)
+	defer os.Remove(tmpFile)
+
 	buffer, err := downloadFileToBuffer(url, *concurrency, *retries)
 	if err != nil {
 		fmt.Printf("Error downloading file: %v\n", err)


### PR DESCRIPTION
- limit concurrency for small files
- potentially let others know how many pgets are running
