### PR TITLE
Implement Download modes

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/replicate/pget/cmd"
 	"github.com/replicate/pget/pkg/config"
 	"github.com/replicate/pget/pkg/download"
-	"github.com/replicate/pget/pkg/extract"
 	"github.com/replicate/pget/pkg/optname"
 )
 
@@ -57,23 +56,6 @@ func execFunc(cmd *cobra.Command, args []string) error {
 	_ = os.WriteFile(tmpFile, []byte(""), 0644)
 	defer os.Remove(tmpFile)
 
-	buffer, fileSize, err := download.FileToBuffer(url)
-	if err != nil {
-		return fmt.Errorf("error downloading file: %w", err)
-	}
-
-	// extract the tar file if the -x flag was provided
-	if viper.GetBool(optname.Extract) {
-		err = extract.ExtractTarFile(buffer, dest, fileSize)
-		if err != nil {
-			return fmt.Errorf("error extracting file: %v", err)
-		}
-	} else {
-		// if -x flag is not set, save the buffer to a file
-		err = os.WriteFile(dest, buffer.Bytes(), 0644)
-		if err != nil {
-			return fmt.Errorf("error writing file: %v", err)
-		}
-	}
-	return nil
+	mode := download.GetMode(config.Mode)
+	return mode.DownloadFile(url, dest)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ var (
 	Extract          bool
 	Force            bool
 	MinimumChunkSize string
+	Mode             string
 	ResolveHosts     []string
 	Retries          int
 	Verbose          bool
@@ -46,7 +47,10 @@ func AddFlags(cmd *cobra.Command) {
 }
 
 func PersistentStartupProcessFlags() error {
-
+	Mode = "buffer"
+	if viper.GetBool(optname.Extract) {
+		Mode = "tar-extract"
+	}
 	if err := convertResolveHostsToMap(); err != nil {
 		return err
 	}

--- a/pkg/download/modes.go
+++ b/pkg/download/modes.go
@@ -1,0 +1,16 @@
+package download
+
+type modeFactoryFunc func() Mode
+
+var modes = map[string]modeFactoryFunc{
+	"buffer":      func() Mode { return &BufferMode{Client: newClient()} },
+	"tar-extract": func() Mode { return &ExtractTarMode{} },
+}
+
+type Mode interface {
+	DownloadFile(url string, dest string) error
+}
+
+func GetMode(name string) Mode {
+	return modes[name]()
+}

--- a/pkg/download/tar_extraction.go
+++ b/pkg/download/tar_extraction.go
@@ -1,0 +1,23 @@
+package download
+
+import (
+	"fmt"
+
+	"github.com/replicate/pget/pkg/extract"
+)
+
+type ExtractTarMode struct {
+}
+
+func (m *ExtractTarMode) DownloadFile(url string, dest string) error {
+	downloader := &BufferMode{Client: newClient()}
+	buffer, fileSize, err := downloader.fileToBuffer(url)
+	if err != nil {
+		return fmt.Errorf("error downloading file: %w", err)
+	}
+	err = extract.ExtractTarFile(buffer, dest, fileSize)
+	if err != nil {
+		return fmt.Errorf("error extracting file: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Add the download mode framework with `buffer` and `tar-extract` to start. This allows us to expand the modes we want to operate in without impacting defaults or other users.