### PR TITLE
Refactor client pool

### DIFF
--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/replicate/pget/pkg/cli"
-	"github.com/replicate/pget/pkg/client"
 	"github.com/replicate/pget/pkg/config"
 	"github.com/replicate/pget/pkg/download"
 	"github.com/replicate/pget/pkg/logging"
@@ -118,13 +117,6 @@ func multifileExecute(manifest manifest) error {
 		logging.Logger.Debug().Int("max_connections_per_host", perHostLimit).Msg("Config")
 	}
 
-	for schemeHost := range manifest {
-		err := handleConnectionPoolCreate(schemeHost)
-		if err != nil {
-			return err
-		}
-	}
-
 	// download each host's files in parallel
 	eg := initializeErrGroup()
 
@@ -142,13 +134,6 @@ func multifileExecute(manifest manifest) error {
 	}
 
 	aggregateAndPrintMetrics(time.Since(multifileDownloadStart))
-	return nil
-}
-
-func handleConnectionPoolCreate(schemeHost string) error {
-	if viper.GetInt(optname.MaxConnPerHost) > 0 {
-		client.CreateHostConnectionPool(schemeHost)
-	}
 	return nil
 }
 

--- a/pkg/download/modes.go
+++ b/pkg/download/modes.go
@@ -3,12 +3,17 @@ package download
 import (
 	"fmt"
 	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/replicate/pget/pkg/client"
+	"github.com/replicate/pget/pkg/optname"
 )
 
 type modeFactoryFunc func() Mode
 
 var modes = map[string]modeFactoryFunc{
-	"buffer":      func() Mode { return &BufferMode{} },
+	"buffer":      func() Mode { return &BufferMode{Client: client.NewClientPool(viper.GetInt(optname.MaxConnPerHost))} },
 	"tar-extract": func() Mode { return &ExtractTarMode{} },
 }
 


### PR DESCRIPTION
This is a refactoring of the client pooling:

* move away from global variables towards a dedicated ClientPool interface

* move away from global config (code in pkg/ shouldn't be making viper.Get* calls)

* make ClientPool responsible for acquiring and releasing clients, hiding it behind the standard Do() interface

* get rid of UserAgentTransport, now that we wrap Do() we can set User-agent there

* create client pools per scheme://host on demand, not up front.  This requires some funky work with a RWMutex so please review this carefully!