### PR TITLE
More cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,8 @@ Pipe to multifile form from another command:
   - Type `Integer`
 
 ### Global Command-Line Options
-- `--concurrency`
-    - Maximum number of chunks for downloading a given file (alias for --max-chunks)
-    - Type: `Integer`
-    - Default: `4 * runtime.NumCPU()`
 - `--max-chunks`
-    - Maximum number of chunks for downloading a given file (alias for --max-chunks)
+    - Maximum number of chunks for downloading a given file
     - Type: `Integer`
     - Default: `4 * runtime.NumCPU()`
 - `--connect-timeout`
@@ -117,6 +113,12 @@ Pipe to multifile form from another command:
   - Verbose mode (equivalent to `--log-level debug`)
   - Type: `bool`
   - Default: `false`
+
+#### Deprecated
+- `--concurrency` (deprecated, use `--max-chunks` instead)
+  - Maximum number of chunks for downloading a given file
+  - Type: `Integer`
+  - Default: `4 * runtime.NumCPU()`
 
 ## Error Handling
 

--- a/cmd/multifile/multifile_test.go
+++ b/cmd/multifile/multifile_test.go
@@ -99,7 +99,7 @@ func TestAddDownloadMetrics(t *testing.T) {
 
 func TestMultifilePreRunE(t *testing.T) {
 	cmd := GetCommand()
-	if err := config.AddFlags(cmd); err != nil {
+	if err := config.AddRootPersistentFlags(cmd); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/multifile/multifile_test.go
+++ b/cmd/multifile/multifile_test.go
@@ -20,25 +20,60 @@ type dummyModeCallerArgs struct {
 }
 
 type dummyMode struct {
-	timesCalled int
-	args        []dummyModeCallerArgs
-	returnErr   bool
+	args      []dummyModeCallerArgs
+	returnErr bool
+	calls     chan dummyModeCallerArgs
 }
 
 // ensure *dummyMode implements download.Mode
 var _ download.Mode = &dummyMode{}
 
 func (d *dummyMode) DownloadFile(url string, dest string) (int64, time.Duration, error) {
-	d.timesCalled++
-	d.args = append(d.args, dummyModeCallerArgs{url, dest})
+	d.calls <- dummyModeCallerArgs{url, dest}
 	if d.returnErr {
 		return -1, time.Duration(0), errors.New("test error")
 	}
 	return 100, time.Duration(1) * time.Second, nil
 }
 
+// Args returns the args that DownloadFile was called with.
+func (d *dummyMode) Args() []dummyModeCallerArgs {
+DONE:
+	// non-blocking read the whole channel into d.args
+	for {
+		select {
+		case args := <-d.calls:
+			d.args = append(d.args, args)
+		default:
+			break DONE
+		}
+	}
+	return d.args
+}
+
+func (d *dummyMode) Arg(i int) dummyModeCallerArgs {
+	return d.Args()[i]
+}
+
+// initializeDummyMode returns a download.Mode that returns an error if returnErr is true
+// This function returns a download.Mode instead of a *dummyMode so that we can ensure
+// that *dummyMode implements download.Mode
+func initializeDummyMode(returnErr bool) download.Mode {
+	dummy := &dummyMode{
+		returnErr: returnErr,
+		calls:     make(chan dummyModeCallerArgs, 100),
+	}
+	return dummy
+}
+
+// getDummyMode returns a dummyMode wrapping initializeDummyMode
+// tests should use getDummyMode instead of initializeDummyMode
+func getDummyMode(returnErr bool) *dummyMode {
+	return initializeDummyMode(returnErr).(*dummyMode)
+}
+
 func TestDownloadFilesFromHost(t *testing.T) {
-	mode := &dummyMode{returnErr: false}
+	mode := getDummyMode(false)
 
 	entries := []manifestEntry{
 		{"https://example.com/file1.txt", "/tmp/file1.txt"},
@@ -53,22 +88,22 @@ func TestDownloadFilesFromHost(t *testing.T) {
 	_ = downloadFilesFromHost(mode, eg, entries, metrics)
 	err := eg.Wait()
 	assert.NoError(t, err)
-	assert.Equal(t, 2, mode.timesCalled)
-	assert.Contains(t, mode.args, dummyModeCallerArgs{entries[0].url, entries[0].dest})
-	assert.Contains(t, mode.args, dummyModeCallerArgs{entries[1].url, entries[1].dest})
+	assert.Equal(t, 2, len(mode.Args()))
+	assert.Contains(t, mode.Args(), dummyModeCallerArgs{entries[0].url, entries[0].dest})
+	assert.Contains(t, mode.Args(), dummyModeCallerArgs{entries[1].url, entries[1].dest})
 
-	failsMode := &dummyMode{returnErr: true}
+	failsMode := getDummyMode(true)
 
 	eg = initializeErrGroup()
 	_ = downloadFilesFromHost(failsMode, eg, entries, metrics)
 	err = eg.Wait()
+	_ = failsMode.Args()
 	assert.Error(t, err)
-
 }
 
 func TestDownloadAndMeasure(t *testing.T) {
 
-	mode := &dummyMode{returnErr: false}
+	mode := getDummyMode(false)
 
 	metrics := &downhloadMetrics{
 		mut: sync.Mutex{},
@@ -78,9 +113,9 @@ func TestDownloadAndMeasure(t *testing.T) {
 	dest := "/tmp/file1.txt"
 	err := downloadAndMeasure(mode, url, dest, metrics)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, mode.timesCalled)
-	assert.Equal(t, url, mode.args[0].url)
-	assert.Equal(t, dest, mode.args[0].dest)
+	assert.Equal(t, 1, len(mode.Args()))
+	assert.Equal(t, url, mode.Arg(0).url)
+	assert.Equal(t, dest, mode.Arg(0).dest)
 }
 
 func TestAddDownloadMetrics(t *testing.T) {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -42,6 +42,16 @@ func GetCommand() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return config.PersistentStartupProcessFlags()
 		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			// Override the default MaxConnsPerHost for the single-file
+			// mode. This will ensure we aren't limited by number of
+			// connections but limited only by the number of chunks.
+			//
+			// This is done in the "Run" command because we want to
+			// only apply when we are running the root command and not
+			// when we are running a subcommand.
+			viper.Set(optname.MaxConnPerHost, 0)
+		},
 		RunE:    runRootCMD,
 		Args:    cobra.ExactArgs(2),
 		Example: `  pget https://example.com/file.tar.gz file.tar.gz`,

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -34,6 +34,11 @@ performance, especially when dealing with large tar files. This makes PGet not j
 efficient file extractor, providing a streamlined solution for fetching and unpacking files.
 `
 
+var (
+	// Config for local flags
+	Extract bool
+)
+
 func GetCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pget [flags] <url> <dest>",
@@ -56,8 +61,9 @@ func GetCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(2),
 		Example: `  pget https://example.com/file.tar.gz file.tar.gz`,
 	}
+	cmd.Flags().BoolVarP(&Extract, optname.Extract, "x", false, "Extract archive after download")
 	cmd.SetUsageTemplate(cli.UsageTemplate)
-	err := config.AddFlags(cmd)
+	err := config.AddRootPersistentFlags(cmd)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -87,7 +87,10 @@ func rootExecute(urlString, dest string) error {
 	_ = os.WriteFile(tmpFile, []byte(""), 0644)
 	defer os.Remove(tmpFile)
 
-	mode := download.GetMode(config.Mode)
-	_, _, err := mode.DownloadFile(urlString, dest)
+	mode, err := download.GetMode(config.Mode)
+	if err != nil {
+		return fmt.Errorf("error getting mode: %w", err)
+	}
+	_, _, err = mode.DownloadFile(urlString, dest)
 	return err
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -97,7 +97,12 @@ func rootExecute(urlString, dest string) error {
 	_ = os.WriteFile(tmpFile, []byte(""), 0644)
 	defer os.Remove(tmpFile)
 
-	mode, err := download.GetMode(config.Mode)
+	modeName := download.BufferModeName
+	if viper.GetBool(optname.Extract) {
+		modeName = download.ExtractTarModeName
+	}
+
+	mode, err := download.GetMode(modeName)
 	if err != nil {
 		return fmt.Errorf("error getting mode: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -4,9 +4,11 @@ import (
 	"os"
 
 	"github.com/replicate/pget/cmd"
+	"github.com/replicate/pget/pkg/logging"
 )
 
 func main() {
+	logging.SetupLogger()
 	rootCMD := cmd.GetRootCommand()
 	if err := rootCMD.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/cli/common_test.go
+++ b/pkg/cli/common_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/replicate/pget/pkg/optname"
+)
+
+func TestEnsureDestinationNotExist(t *testing.T) {
+	defer viper.Reset()
+	f, err := os.CreateTemp("", "EnsureDestinationNotExist-test-file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	testCases := []struct {
+		name     string
+		fileName string
+		force    bool
+		err      bool
+	}{
+		{"force true, file exists", f.Name(), true, false},
+		{"force false, file exists", f.Name(), false, true},
+		{"force true, file does not exist", f.Name(), true, false},
+		{"force false, file does not exist", "unknownFile", false, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Set(optname.Force, tc.force)
+			err := EnsureDestinationNotExist(tc.fileName)
+			assert.Equal(t, tc.err, err != nil)
+		})
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,7 +25,7 @@ const (
 	retryMaxWait = 1250 * time.Millisecond
 )
 
-var logger = logging.Logger
+var logger = logging.GetLogger()
 
 // HTTPClient is a wrapper around http.Client that allows for limiting the number of concurrent connections per host
 // utilizing a client pool. If the MaxConnPerHost option is not set, the client pool will not be used.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -41,7 +41,7 @@ func (c *HTTPClient) Do(req *http.Request) (*http.Response, error) {
 // NewClient factory function returns a new http.Client with the appropriate settings and can limit number of clients
 // per host if the MaxConnPerHost option is set.
 func NewClient(forceHTTP2 bool, maxConnPerHost int) *HTTPClient {
-	disableKeepalives := !viper.GetBool(optname.ForceHTTP2)
+	disableKeepAlives := !forceHTTP2
 
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -54,7 +54,7 @@ func NewClient(forceHTTP2 bool, maxConnPerHost int) *HTTPClient {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   5 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		DisableKeepAlives:     disableKeepalives,
+		DisableKeepAlives:     disableKeepAlives,
 	}
 	transport.MaxConnsPerHost = maxConnPerHost
 	transport.MaxIdleConnsPerHost = maxConnPerHost

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,7 +40,7 @@ func (c *HTTPClient) Do(req *http.Request) (*http.Response, error) {
 
 // NewHTTPClient factory function returns a new http.Client with the appropriate settings and can limit number of clients
 // per host if the MaxConnPerHost option is set.
-func NewHTTPClient(forceHTTP2 bool, maxConnPerHost int) *HTTPClient {
+func NewHTTPClient(forceHTTP2 bool, maxConnPerHost, maxRetries int) *HTTPClient {
 	disableKeepAlives := !forceHTTP2
 
 	transport := &http.Transport{
@@ -67,7 +67,7 @@ func NewHTTPClient(forceHTTP2 bool, maxConnPerHost int) *HTTPClient {
 		Logger:       nil,
 		RetryWaitMin: retryMinWait,
 		RetryWaitMax: retryMaxWait,
-		RetryMax:     viper.GetInt(optname.Retries),
+		RetryMax:     maxRetries,
 		CheckRetry:   retryablehttp.DefaultRetryPolicy,
 		Backoff:      linearJitterRetryAfterBackoff,
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -38,9 +38,9 @@ func (c *HTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return c.Client.Do(req)
 }
 
-// NewClient factory function returns a new http.Client with the appropriate settings and can limit number of clients
+// NewHTTPClient factory function returns a new http.Client with the appropriate settings and can limit number of clients
 // per host if the MaxConnPerHost option is set.
-func NewClient(forceHTTP2 bool, maxConnPerHost int) *HTTPClient {
+func NewHTTPClient(forceHTTP2 bool, maxConnPerHost int) *HTTPClient {
 	disableKeepAlives := !forceHTTP2
 
 	transport := &http.Transport{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,9 +28,8 @@ var (
 	Verbose          bool
 )
 
-var logger = logging.GetLogger()
-
 // HostToIPResolutionMap is a map of hostnames to IP addresses
+// TODO: Eliminate this global variable
 var HostToIPResolutionMap = make(map[string]string)
 
 func AddRootPersistentFlags(cmd *cobra.Command) error {
@@ -96,6 +95,7 @@ func setLogLevel(logLevel string) {
 }
 
 func convertResolveHostsToMap() error {
+	logger := logging.GetLogger()
 	for _, resolveHost := range viper.GetStringSlice(optname.Resolve) {
 		split := strings.SplitN(resolveHost, ":", 3)
 		if len(split) != 3 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	ConnTimeout      time.Duration
-	Extract          bool
 	Force            bool
 	ForceHTTP2       bool
 	IgnoreRetryAfter bool
@@ -34,9 +33,7 @@ var logger = logging.GetLogger()
 // HostToIPResolutionMap is a map of hostnames to IP addresses
 var HostToIPResolutionMap = make(map[string]string)
 
-func AddFlags(cmd *cobra.Command) error {
-	// Non-Persistent Flags (only applies to rootCMD)
-	cmd.Flags().BoolVarP(&Extract, optname.Extract, "x", false, "Extract archive after download")
+func AddRootPersistentFlags(cmd *cobra.Command) error {
 	// Persistent Flags (applies to all commands/subcommands)
 	cmd.PersistentFlags().IntVar(&MaxChunkNumber, optname.Concurrency, runtime.GOMAXPROCS(0)*4, "Maximum number of concurrent downloads/maximum number of chunks for a given file (alias for --max-chunks)")
 	cmd.PersistentFlags().IntVarP(&MaxChunkNumber, optname.MaxChunks, "c", runtime.GOMAXPROCS(0)*4, "Maximum number of chunks for a given file")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ var HostToIPResolutionMap = make(map[string]string)
 
 func AddRootPersistentFlags(cmd *cobra.Command) error {
 	// Persistent Flags (applies to all commands/subcommands)
-	cmd.PersistentFlags().IntVar(&MaxChunkNumber, optname.Concurrency, runtime.GOMAXPROCS(0)*4, "Maximum number of concurrent downloads/maximum number of chunks for a given file (alias for --max-chunks)")
+	cmd.PersistentFlags().IntVar(&MaxChunkNumber, optname.Concurrency, runtime.GOMAXPROCS(0)*4, "Maximum number of concurrent downloads/maximum number of chunks for a given file")
 	cmd.PersistentFlags().IntVarP(&MaxChunkNumber, optname.MaxChunks, "c", runtime.GOMAXPROCS(0)*4, "Maximum number of chunks for a given file")
 	cmd.PersistentFlags().DurationVar(&ConnTimeout, optname.ConnTimeout, 5*time.Second, "Timeout for establishing a connection, format is <number><unit>, e.g. 10s")
 	cmd.PersistentFlags().StringVarP(&MinimumChunkSize, optname.MinimumChunkSize, "m", "16M", "Minimum chunk size (in bytes) to use when downloading a file (e.g. 10M)")
@@ -61,6 +61,12 @@ func AddRootPersistentFlags(cmd *cobra.Command) error {
 	// Hide flags from help, these are intended to be used for testing/internal benchmarking/debugging only
 	if err := cmd.PersistentFlags().MarkHidden(optname.ForceHTTP2); err != nil {
 		return fmt.Errorf("failed to hide flag %s: %w", optname.ForceHTTP2, err)
+	}
+
+	// Deprecated flags
+	err := cmd.PersistentFlags().MarkDeprecated(optname.Concurrency, "use --max-chunks instead")
+	if err != nil {
+		return fmt.Errorf("failed to mark flag as deprecated: %w", err)
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,6 @@ var (
 	LoggingLevel     string
 	MaxChunkNumber   int
 	MinimumChunkSize string
-	Mode             string
 	ResolveHosts     []string
 	Retries          int
 	Verbose          bool
@@ -72,12 +71,20 @@ func AddFlags(cmd *cobra.Command) error {
 }
 
 func PersistentStartupProcessFlags() error {
-	Mode = "buffer"
 	if viper.GetBool(optname.Verbose) {
 		viper.Set(optname.LoggingLevel, "debug")
 	}
+	setLogLevel(viper.GetString(optname.LoggingLevel))
+	if err := convertResolveHostsToMap(); err != nil {
+		return err
+	}
+	return nil
+
+}
+
+func setLogLevel(logLevel string) {
 	// Set log-level
-	switch strings.ToLower(viper.GetString(optname.LoggingLevel)) {
+	switch logLevel {
 	case "debug":
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	case "info":
@@ -89,14 +96,6 @@ func PersistentStartupProcessFlags() error {
 	default:
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
-	if viper.GetBool(optname.Extract) {
-		Mode = "tar-extract"
-	}
-	if err := convertResolveHostsToMap(); err != nil {
-		return err
-	}
-	return nil
-
 }
 
 func convertResolveHostsToMap() error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,8 @@ var (
 	Verbose          bool
 )
 
+var logger = logging.GetLogger()
+
 // HostToIPResolutionMap is a map of hostnames to IP addresses
 var HostToIPResolutionMap = make(map[string]string)
 
@@ -116,9 +118,9 @@ func convertResolveHostsToMap() error {
 		}
 		HostToIPResolutionMap[hostPort] = net.JoinHostPort(addr, port)
 	}
-	if logging.Logger.GetLevel() == zerolog.DebugLevel {
+	if logger.GetLevel() == zerolog.DebugLevel {
 		for key, elem := range HostToIPResolutionMap {
-			logging.Logger.Debug().Str("host_port", key).Str("resolve_target", elem).Msg("Config")
+			logger.Debug().Str("host_port", key).Str("resolve_target", elem).Msg("Config")
 		}
 	}
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	"github.com/replicate/pget/pkg/optname"
-	"github.com/rs/zerolog"
-	"github.com/spf13/viper"
 	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/replicate/pget/pkg/optname"
 )
 
 func TestSetLogLevel(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"github.com/replicate/pget/pkg/optname"
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetLogLevel(t *testing.T) {
+	testCases := []struct {
+		name     string
+		logLevel string
+	}{
+		{"debug", "debug"},
+		{"info", "info"},
+		{"warn", "warn"},
+		{"error", "error"},
+		{"unknown", "info"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setLogLevel(tc.logLevel)
+			assert.Equal(t, tc.logLevel, zerolog.GlobalLevel().String())
+		})
+	}
+}
+
+func TestConvertResolveHostsToMap(t *testing.T) {
+	defer func() {
+		HostToIPResolutionMap = map[string]string{}
+		viper.Reset()
+	}()
+
+	testCases := []struct {
+		name     string
+		resolve  []string
+		expected map[string]string
+		err      bool
+	}{
+		{"empty", []string{}, map[string]string{}, false},
+		{"single", []string{"example.com:80:127.0.0.1"}, map[string]string{"example.com:80": "127.0.0.1:80"}, false},
+		{"multiple", []string{"example.com:80:127.0.0.1", "example.com:443:127.0.0.1"}, map[string]string{"example.com:80": "127.0.0.1:80", "example.com:443": "127.0.0.1:443"}, false},
+		{"invalid ip", []string{"example.com:80:InvalidIPAddr"}, map[string]string{}, true},
+		{"duplicate host", []string{"example.com:80:127.0.0.1", "example.com:80:127.0.0.2"}, map[string]string{"example.com:80": "127.0.0.1:80"}, true},
+		{"invalid format", []string{"example.com:80"}, map[string]string{}, true},
+		{"invalid hostname format, is IP Addr", []string{"127.0.0.1:443:127.0.0.2"}, map[string]string{}, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			HostToIPResolutionMap = map[string]string{}
+			viper.Set(optname.Resolve, strings.Join(tc.resolve, " "))
+			err := convertResolveHostsToMap()
+			assert.Equal(t, tc.err, err != nil)
+			assert.Equal(t, tc.expected, HostToIPResolutionMap)
+			viper.Reset()
+		})
+	}
+}

--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -37,6 +37,12 @@ func (t *Target) Basename() string {
 	return filepath.Base(t.Dest)
 }
 
+func getBufferMode(config ModeConfiguration) Mode {
+	return &BufferMode{
+		Client: client.NewHTTPClient(config.forceHTTP2, config.maxConnPerHost),
+	}
+}
+
 func (m *BufferMode) getRemoteFileSize(ctx context.Context, target Target) (string, int64, error) {
 	logger := logging.GetLogger()
 	req, err := http.NewRequestWithContext(ctx, "HEAD", target.URL, nil)

--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -39,7 +39,7 @@ func (t *Target) Basename() string {
 
 func getBufferMode(config ModeConfiguration) Mode {
 	return &BufferMode{
-		Client: client.NewHTTPClient(config.forceHTTP2, config.maxConnPerHost),
+		Client: client.NewHTTPClient(config.forceHTTP2, config.maxConnPerHost, config.maxRetries),
 	}
 }
 

--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -20,6 +20,8 @@ import (
 	"github.com/replicate/pget/pkg/optname"
 )
 
+const BufferModeName = "buffer"
+
 type BufferMode struct {
 	Client *client.HTTPClient
 }

--- a/pkg/download/modes.go
+++ b/pkg/download/modes.go
@@ -15,6 +15,7 @@ type modeFactory func(config ModeConfiguration) Mode
 type ModeConfiguration struct {
 	maxConnPerHost int
 	forceHTTP2     bool
+	maxRetries     int
 }
 
 type Mode interface {
@@ -43,5 +44,6 @@ func getModeConfig() ModeConfiguration {
 	return ModeConfiguration{
 		maxConnPerHost: viper.GetInt(optname.MaxConnPerHost),
 		forceHTTP2:     viper.GetBool(optname.ForceHTTP2),
+		maxRetries:     viper.GetInt(optname.Retries),
 	}
 }

--- a/pkg/download/modes_test.go
+++ b/pkg/download/modes_test.go
@@ -1,11 +1,12 @@
 package download
 
 import (
-	"github.com/replicate/pget/pkg/optname"
-	"github.com/spf13/viper"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/replicate/pget/pkg/optname"
 )
 
 func TestGetMode(t *testing.T) {

--- a/pkg/download/modes_test.go
+++ b/pkg/download/modes_test.go
@@ -1,0 +1,40 @@
+package download
+
+import (
+	"github.com/replicate/pget/pkg/optname"
+	"github.com/spf13/viper"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMode(t *testing.T) {
+	testCases := []struct {
+		name     string
+		modeName string
+		mode     Mode
+		err      bool
+	}{
+		{"Get BufferMode", BufferModeName, &BufferMode{}, false},
+		{"Get ExtractTarMode", ExtractTarModeName, &ExtractTarMode{}, false},
+		{"Get Unknown Mode", "invalid", nil, true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, err := GetMode(tc.modeName)
+			assert.IsType(t, tc.mode, mode)
+			assert.Equal(t, tc.err, err != nil)
+		})
+	}
+}
+
+func TestGetBufferMode(t *testing.T) {
+	config := getModeConfig()
+	assert.IsType(t, &BufferMode{}, getBufferMode(config))
+}
+
+func TestGetModeConfig(t *testing.T) {
+	config := getModeConfig()
+	assert.Equal(t, viper.GetInt(optname.MaxConnPerHost), config.maxConnPerHost)
+	assert.Equal(t, viper.GetBool(optname.ForceHTTP2), config.forceHTTP2)
+}

--- a/pkg/download/tar_extraction.go
+++ b/pkg/download/tar_extraction.go
@@ -18,7 +18,7 @@ type ExtractTarMode struct {
 func getExtractTarMode(config ModeConfiguration) Mode {
 	return &ExtractTarMode{
 		BufferMode: BufferMode{
-			Client: client.NewHTTPClient(config.forceHTTP2, config.maxConnPerHost),
+			Client: client.NewHTTPClient(config.forceHTTP2, config.maxConnPerHost, config.maxRetries),
 		},
 	}
 }

--- a/pkg/download/tar_extraction.go
+++ b/pkg/download/tar_extraction.go
@@ -3,22 +3,31 @@ package download
 import (
 	"context"
 	"fmt"
+	"github.com/replicate/pget/pkg/client"
 	"time"
 
 	"github.com/replicate/pget/pkg/extract"
 )
 
-const TarExtractModeName = "tar-extract"
+const ExtractTarModeName = "tar-extract"
 
 type ExtractTarMode struct {
+	BufferMode
+}
+
+func getExtractTarMode(config ModeConfiguration) Mode {
+	return &ExtractTarMode{
+		BufferMode: BufferMode{
+			Client: client.NewHTTPClient(config.forceHTTP2, config.maxConnPerHost),
+		},
+	}
 }
 
 func (m *ExtractTarMode) DownloadFile(url string, dest string) (int64, time.Duration, error) {
 	ctx := context.Background()
 	startTime := time.Now()
 	target := Target{URL: url, TrueURL: url, Dest: dest}
-	downloader := &BufferMode{}
-	buffer, fileSize, err := downloader.fileToBuffer(ctx, target)
+	buffer, fileSize, err := m.fileToBuffer(ctx, target)
 	if err != nil {
 		return int64(-1), 0, fmt.Errorf("error downloading file: %w", err)
 	}

--- a/pkg/download/tar_extraction.go
+++ b/pkg/download/tar_extraction.go
@@ -3,9 +3,9 @@ package download
 import (
 	"context"
 	"fmt"
-	"github.com/replicate/pget/pkg/client"
 	"time"
 
+	"github.com/replicate/pget/pkg/client"
 	"github.com/replicate/pget/pkg/extract"
 )
 

--- a/pkg/download/tar_extraction.go
+++ b/pkg/download/tar_extraction.go
@@ -8,6 +8,8 @@ import (
 	"github.com/replicate/pget/pkg/extract"
 )
 
+const TarExtractModeName = "tar-extract"
+
 type ExtractTarMode struct {
 }
 

--- a/pkg/extract/tar.go
+++ b/pkg/extract/tar.go
@@ -17,6 +17,7 @@ import (
 func ExtractTarFile(buffer *bytes.Buffer, destDir string, fileSize int64) error {
 	startTime := time.Now()
 	tarReader := tar.NewReader(buffer)
+	logger := logging.GetLogger()
 
 	for {
 		header, err := tarReader.Next()
@@ -59,7 +60,7 @@ func ExtractTarFile(buffer *bytes.Buffer, destDir string, fileSize int64) error 
 	elapsed := time.Since(startTime).Seconds()
 	size := humanize.Bytes(uint64(fileSize))
 	throughput := humanize.Bytes(uint64(float64(fileSize) / elapsed))
-	logging.Logger.Info().
+	logger.Info().
 		Str("size", size).
 		Str("elapsed", fmt.Sprintf("%.3fs", elapsed)).
 		Str("throughput", throughput).

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -10,9 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var Logger zerolog.Logger
-
-func init() {
+func SetupLogger() {
 	// TODO: Make color configurable? Disabled so we don't have to deal with ANSI escape codes in our logoutput
 	output := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339, NoColor: true}
 	output.FormatLevel = func(i interface{}) string {
@@ -22,5 +20,8 @@ func init() {
 		return fmt.Sprintf("[ %s ]", i)
 	}
 	log.Logger = zerolog.New(output).With().Timestamp().Logger()
-	Logger = log.Logger
+}
+
+func GetLogger() zerolog.Logger {
+	return log.Logger
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,33 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	defer func() {
+		Version = ""
+		CommitHash = ""
+		BuildTime = ""
+	}()
+
+	testCases := []struct {
+		name     string
+		version  string
+		commit   string
+		expected string
+	}{
+		{"development", "development", "", "development"},
+		{"tagged release", "v1.0.0", "deadbeef", "v1.0.0()"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			Version = tc.version
+			actual := GetVersion()
+			if actual != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Do not call Viper for the sake of calling Viper
* Remove Globals for Modes
* Set MaxConnPerHost for 0 when root cmd is run
* Improve Mode Factories
* Isolate MaxRetries and pass down instead of using Viper in client code
* Improve Download Metrics (and eliminate globals)
* Implement Tests for EnsureDestinationNotExist
* Implement Tests for config module
* Remove global Logger in Config
* Implement testing for version module
* Fix flaky test