### PR TITLE
Test and benchmark downloading

### DIFF
--- a/pkg/download/buffer_slow_test.go
+++ b/pkg/download/buffer_slow_test.go
@@ -1,0 +1,26 @@
+//go:build slow
+// +build slow
+
+package download
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func BenchmarkDownload10G(b *testing.B) { benchmarkDownloadSingleFile(10*1024*1024*1024, b) }
+
+func BenchmarkDownloadDollyTensors(b *testing.B) {
+	bufferMode := makeBufferMode()
+
+	for n := 0; n < b.N; n++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		url := "https://storage.googleapis.com/replicate-weights/dolly-v2-12b-fp16.tensors"
+		_, _, err := bufferMode.fileToBuffer(ctx, Target{URL: url, TrueURL: url})
+		assert.NoError(b, err)
+	}
+}

--- a/pkg/download/buffer_slow_test.go
+++ b/pkg/download/buffer_slow_test.go
@@ -10,7 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func BenchmarkDownload10G(b *testing.B) { benchmarkDownloadSingleFile(10*1024*1024*1024, b) }
+func BenchmarkDownload10G(b *testing.B) {
+	benchmarkDownloadSingleFile(defaultOpts, 10*1024*1024*1024, b)
+}
+func BenchmarkDownload10GH2(b *testing.B) {
+	benchmarkDownloadSingleFile(http2Opts, 10*1024*1024*1024, b)
+}
 
 func BenchmarkDownloadDollyTensors(b *testing.B) {
 	bufferMode := makeBufferMode()

--- a/pkg/download/buffer_test.go
+++ b/pkg/download/buffer_test.go
@@ -12,10 +12,11 @@ import (
 	"testing/fstest"
 	"testing/iotest"
 
-	"github.com/replicate/pget/pkg/client"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/pget/pkg/client"
 )
 
 var testFS = fstest.MapFS{

--- a/pkg/download/buffer_test.go
+++ b/pkg/download/buffer_test.go
@@ -1,4 +1,4 @@
-package download_test
+package download
 
 import (
 	"io"
@@ -13,7 +13,6 @@ import (
 	"testing/iotest"
 
 	"github.com/replicate/pget/pkg/client"
-	"github.com/replicate/pget/pkg/download"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,7 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)
 }
 
-func makeBufferMode() *download.BufferMode {
+func makeBufferMode() *BufferMode {
 	clientOpts := client.Options{
 		MaxConnPerHost: 40,
 		ForceHTTP2:     false,
@@ -35,7 +34,7 @@ func makeBufferMode() *download.BufferMode {
 	}
 	client := client.NewHTTPClient(clientOpts)
 
-	return &download.BufferMode{Client: client}
+	return &BufferMode{Client: client}
 }
 
 func tempFilename() string {
@@ -138,16 +137,3 @@ func BenchmarkDownload10K(b *testing.B)  { benchmarkDownloadSingleFile(10*1024, 
 func BenchmarkDownload10M(b *testing.B)  { benchmarkDownloadSingleFile(10*1024*1024, b) }
 func BenchmarkDownload100M(b *testing.B) { benchmarkDownloadSingleFile(100*1024*1024, b) }
 func BenchmarkDownload1G(b *testing.B)   { benchmarkDownloadSingleFile(1024*1024*1024, b) }
-func BenchmarkDownload10G(b *testing.B)  { benchmarkDownloadSingleFile(10*1024*1024*1024, b) }
-
-func BenchmarkDownloadDollyTensors(b *testing.B) {
-	bufferMode := makeBufferMode()
-
-	for n := 0; n < b.N; n++ {
-		dest := tempFilename()
-		defer os.Remove(dest)
-
-		_, _, err := bufferMode.DownloadFile("https://storage.googleapis.com/replicate-weights/dolly-v2-12b-fp16.tensors", dest)
-		assert.NoError(b, err)
-	}
-}

--- a/pkg/download/buffer_test.go
+++ b/pkg/download/buffer_test.go
@@ -139,3 +139,15 @@ func BenchmarkDownload10M(b *testing.B)  { benchmarkDownloadSingleFile(10*1024*1
 func BenchmarkDownload100M(b *testing.B) { benchmarkDownloadSingleFile(100*1024*1024, b) }
 func BenchmarkDownload1G(b *testing.B)   { benchmarkDownloadSingleFile(1024*1024*1024, b) }
 func BenchmarkDownload10G(b *testing.B)  { benchmarkDownloadSingleFile(10*1024*1024*1024, b) }
+
+func BenchmarkDownloadDollyTensors(b *testing.B) {
+	bufferMode := makeBufferMode()
+
+	for n := 0; n < b.N; n++ {
+		dest := tempFilename()
+		defer os.Remove(dest)
+
+		_, _, err := bufferMode.DownloadFile("https://storage.googleapis.com/replicate-weights/dolly-v2-12b-fp16.tensors", dest)
+		assert.NoError(b, err)
+	}
+}

--- a/pkg/download/buffer_test.go
+++ b/pkg/download/buffer_test.go
@@ -2,19 +2,29 @@ package download_test
 
 import (
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
+	"testing/iotest"
 
 	"github.com/replicate/pget/pkg/client"
 	"github.com/replicate/pget/pkg/download"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testFS = fstest.MapFS{
 	"hello.txt": {Data: []byte("hello, world!")},
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
 }
 
 func makeBufferMode() *download.BufferMode {
@@ -36,15 +46,46 @@ func tempFilename() string {
 	return dest.Name()
 }
 
+// writeRandomFile creates a sparse file with the given size and
+// writes some random bytes somewhere in it.  This is much faster than
+// filling the whole file with random bytes would be, but it also
+// gives us some confidence that the range requests are being
+// reassembled correctly.
+func writeRandomFile(t require.TestingT, path string, size int64) {
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer file.Close()
+
+	rnd := rand.New(rand.NewSource(99))
+
+	// under 1 MiB, just fill the whole file with random data
+	if size < 1024*1024 {
+		_, err = io.CopyN(file, rnd, size)
+		require.NoError(t, err)
+		return
+	}
+
+	// set the file size
+	err = file.Truncate(size)
+	require.NoError(t, err)
+
+	// write some random data to the start
+	_, err = io.CopyN(file, rnd, 1024)
+	require.NoError(t, err)
+
+	// and somewhere else in the file
+	_, err = file.Seek(rnd.Int63()%(size-1024), io.SeekStart)
+	require.NoError(t, err)
+	_, err = io.CopyN(file, rnd, 1024)
+	require.NoError(t, err)
+}
+
 func assertFileHasContent(t *testing.T, expectedContent []byte, path string) {
 	contentFile, err := os.Open(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer contentFile.Close()
 
-	content, err := io.ReadAll(contentFile)
-	assert.NoError(t, err)
-
-	assert.Equal(t, expectedContent, content)
+	assert.NoError(t, iotest.TestReader(contentFile, expectedContent))
 }
 
 func TestDownloadSmallFile(t *testing.T) {
@@ -59,6 +100,42 @@ func TestDownloadSmallFile(t *testing.T) {
 	_, _, err := bufferMode.DownloadFile(ts.URL+"/hello.txt", dest)
 	assert.NoError(t, err)
 
-	assert.FileExists(t, dest)
 	assertFileHasContent(t, testFS["hello.txt"].Data, dest)
 }
+
+func benchmarkDownloadSingleFile(size int64, b *testing.B) {
+	dir, err := os.MkdirTemp("", "pget-buffer-test")
+	require.NoError(b, err)
+	defer os.RemoveAll(dir)
+
+	srcFilename := filepath.Join(dir, "random-bytes")
+
+	writeRandomFile(b, srcFilename, size)
+
+	ts := httptest.NewServer(http.FileServer(http.Dir(dir)))
+	defer ts.Close()
+
+	bufferMode := makeBufferMode()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		dest := tempFilename()
+		defer os.Remove(dest)
+
+		_, _, err = bufferMode.DownloadFile(ts.URL+"/random-bytes", dest)
+		assert.NoError(b, err)
+
+		// don't count `diff` in benchmark time
+		b.StopTimer()
+		cmd := exec.Command("diff", "-q", srcFilename, dest)
+		err = cmd.Run()
+		assert.NoError(b, err, "source file and dest file should be identical")
+		b.StartTimer()
+	}
+}
+
+func BenchmarkDownload10K(b *testing.B)  { benchmarkDownloadSingleFile(10*1024, b) }
+func BenchmarkDownload10M(b *testing.B)  { benchmarkDownloadSingleFile(10*1024*1024, b) }
+func BenchmarkDownload100M(b *testing.B) { benchmarkDownloadSingleFile(100*1024*1024, b) }
+func BenchmarkDownload1G(b *testing.B)   { benchmarkDownloadSingleFile(1024*1024*1024, b) }
+func BenchmarkDownload10G(b *testing.B)  { benchmarkDownloadSingleFile(10*1024*1024*1024, b) }

--- a/pkg/download/buffer_test.go
+++ b/pkg/download/buffer_test.go
@@ -1,0 +1,64 @@
+package download_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"testing/fstest"
+
+	"github.com/replicate/pget/pkg/client"
+	"github.com/replicate/pget/pkg/download"
+	"github.com/stretchr/testify/assert"
+)
+
+var testFS = fstest.MapFS{
+	"hello.txt": {Data: []byte("hello, world!")},
+}
+
+func makeBufferMode() *download.BufferMode {
+	clientOpts := client.Options{
+		MaxConnPerHost: 40,
+		ForceHTTP2:     false,
+		MaxRetries:     2,
+	}
+	client := client.NewHTTPClient(clientOpts)
+
+	return &download.BufferMode{Client: client}
+}
+
+func tempFilename() string {
+	// get a temp filename that doesn't already exist by creating
+	// a temp file and immediately deleting it
+	dest, _ := os.CreateTemp("", "pget-buffer-test")
+	os.Remove(dest.Name())
+	return dest.Name()
+}
+
+func assertFileHasContent(t *testing.T, expectedContent []byte, path string) {
+	contentFile, err := os.Open(path)
+	assert.NoError(t, err)
+	defer contentFile.Close()
+
+	content, err := io.ReadAll(contentFile)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedContent, content)
+}
+
+func TestDownloadSmallFile(t *testing.T) {
+	ts := httptest.NewServer(http.FileServer(http.FS(testFS)))
+	defer ts.Close()
+
+	dest := tempFilename()
+	defer os.Remove(dest)
+
+	bufferMode := makeBufferMode()
+
+	_, _, err := bufferMode.DownloadFile(ts.URL+"/hello.txt", dest)
+	assert.NoError(t, err)
+
+	assert.FileExists(t, dest)
+	assertFileHasContent(t, testFS["hello.txt"].Data, dest)
+}


### PR DESCRIPTION
This adds a test (based on an in-memory filesystem) and a few benchmarks (based on synthetic files created in a temp dir, and one real file in GCS).

Slow benchmarks are guarded by a `slow` build tag; they will only run if you add `--tags=slow` to your `go test` invocation.