### PR TITLE
Cleanup context

### DIFF
--- a/cmd/multifile/multifile_test.go
+++ b/cmd/multifile/multifile_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/replicate/pget/pkg/config"
 	"github.com/replicate/pget/pkg/download"
@@ -85,9 +86,9 @@ func TestDownloadFilesFromHost(t *testing.T) {
 		mut: sync.Mutex{},
 	}
 
-	ctx, eg := initializeErrGroup(context.Background())
-	_ = downloadFilesFromHost(ctx, mode, eg, entries, metrics)
-	err := eg.Wait()
+	errGroup, ctx := errgroup.WithContext(context.Background())
+	_ = downloadFilesFromHost(ctx, mode, errGroup, entries, metrics)
+	err := errGroup.Wait()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(mode.Args()))
 	assert.Contains(t, mode.Args(), dummyModeCallerArgs{entries[0].url, entries[0].dest})
@@ -95,9 +96,9 @@ func TestDownloadFilesFromHost(t *testing.T) {
 
 	failsMode := getDummyMode(true)
 
-	ctx, eg = initializeErrGroup(context.Background())
-	_ = downloadFilesFromHost(ctx, failsMode, eg, entries, metrics)
-	err = eg.Wait()
+	errGroup, ctx = errgroup.WithContext(context.Background())
+	_ = downloadFilesFromHost(ctx, failsMode, errGroup, entries, metrics)
+	err = errGroup.Wait()
 	_ = failsMode.Args()
 	assert.Error(t, err)
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -80,7 +81,7 @@ func runRootCMD(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := rootExecute(urlString, dest); err != nil {
+	if err := rootExecute(cmd.Context(), urlString, dest); err != nil {
 		return err
 	}
 
@@ -89,7 +90,7 @@ func runRootCMD(cmd *cobra.Command, args []string) error {
 
 // rootExecute is the main function of the program and encapsulates the general logic
 // returns any/all errors to the caller.
-func rootExecute(urlString, dest string) error {
+func rootExecute(ctx context.Context, urlString, dest string) error {
 	// allows us to see how many pget procs are running at a time
 	tmpFile := fmt.Sprintf("/tmp/.pget-%d", os.Getpid())
 	_ = os.WriteFile(tmpFile, []byte(""), 0644)
@@ -114,6 +115,6 @@ func rootExecute(urlString, dest string) error {
 	if err != nil {
 		return fmt.Errorf("error getting mode: %w", err)
 	}
-	_, _, err = mode.DownloadFile(urlString, dest)
+	_, _, err = mode.DownloadFile(ctx, urlString, dest)
 	return err
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -91,11 +91,6 @@ func runRootCMD(cmd *cobra.Command, args []string) error {
 // rootExecute is the main function of the program and encapsulates the general logic
 // returns any/all errors to the caller.
 func rootExecute(ctx context.Context, urlString, dest string) error {
-	// allows us to see how many pget procs are running at a time
-	tmpFile := fmt.Sprintf("/tmp/.pget-%d", os.Getpid())
-	_ = os.WriteFile(tmpFile, []byte(""), 0644)
-	defer os.Remove(tmpFile)
-
 	minChunkSize, err := humanize.ParseBytes(viper.GetString(optname.MinimumChunkSize))
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/replicate/pget/cmd"
@@ -10,6 +11,12 @@ import (
 func main() {
 	logging.SetupLogger()
 	rootCMD := cmd.GetRootCommand()
+
+	// allows us to see how many pget procs are running at a time
+	tmpFile := fmt.Sprintf("/tmp/.pget-%d", os.Getpid())
+	_ = os.WriteFile(tmpFile, []byte(""), 0644)
+	defer os.Remove(tmpFile)
+
 	if err := rootCMD.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -198,8 +198,7 @@ func (m *BufferMode) downloadChunk(resp *http.Response, dataSlice []byte) error 
 	return nil
 }
 
-func (m *BufferMode) DownloadFile(url string, dest string) (int64, time.Duration, error) {
-	ctx := context.Background()
+func (m *BufferMode) DownloadFile(ctx context.Context, url string, dest string) (int64, time.Duration, error) {
 	logger := logging.GetLogger()
 	schemeHost, err := client.GetSchemeHostKey(url)
 	if err != nil {

--- a/pkg/download/buffer_test.go
+++ b/pkg/download/buffer_test.go
@@ -96,7 +96,7 @@ func TestDownloadSmallFile(t *testing.T) {
 
 	bufferMode := makeBufferMode(defaultOpts)
 
-	_, _, err := bufferMode.DownloadFile(ts.URL+"/hello.txt", dest)
+	_, _, err := bufferMode.DownloadFile(context.Background(), ts.URL+"/hello.txt", dest)
 	assert.NoError(t, err)
 
 	assertFileHasContent(t, testFS["hello.txt"].Data, dest)
@@ -119,7 +119,7 @@ func testDownloadSingleFile(opts Options, size int64, t *testing.T) {
 	dest := tempFilename()
 	defer os.Remove(dest)
 
-	_, _, err = bufferMode.DownloadFile(ts.URL+"/random-bytes", dest)
+	_, _, err = bufferMode.DownloadFile(context.Background(), ts.URL+"/random-bytes", dest)
 	assert.NoError(t, err)
 
 	cmd := exec.Command("diff", "-q", srcFilename, dest)

--- a/pkg/download/modes.go
+++ b/pkg/download/modes.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -10,7 +11,7 @@ import (
 type modeFactory func(opts Options) Mode
 
 type Mode interface {
-	DownloadFile(url string, dest string) (fileSize int64, elapsedTime time.Duration, err error)
+	DownloadFile(ctx context.Context, url string, dest string) (fileSize int64, elapsedTime time.Duration, err error)
 }
 
 type Options struct {

--- a/pkg/download/tar_extraction.go
+++ b/pkg/download/tar_extraction.go
@@ -25,8 +25,7 @@ func getExtractTarMode(opts Options) Mode {
 	}
 }
 
-func (m *ExtractTarMode) DownloadFile(url string, dest string) (int64, time.Duration, error) {
-	ctx := context.Background()
+func (m *ExtractTarMode) DownloadFile(ctx context.Context, url string, dest string) (int64, time.Duration, error) {
 	startTime := time.Now()
 	target := Target{URL: url, TrueURL: url, Dest: dest}
 	buffer, fileSize, err := m.fileToBuffer(ctx, target)


### PR DESCRIPTION
Cleanup context (pass it through from root) and remove useless option related to max concurrent files. We do not need to leverage the errgroup to limit the number of downloads any longer. We're using MaxConnPerHost to do this.