### PR TITLE
BUGFIX: Correct order of downloadOpts population

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -170,15 +170,16 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 	getter := pget.Getter{
 		Downloader: download.GetBufferMode(downloadOpts),
 	}
+
 	if srvName := viper.GetString(config.OptCacheNodesSRVName); srvName != "" {
 		downloadOpts.SliceSize = 512 * humanize.MiByte
 		// FIXME: make this a config option
 		downloadOpts.DomainsToCache = []string{"weights.replicate.delivery"}
-		getter.Downloader, err = download.GetConsistentHashingMode(downloadOpts)
+		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
 		if err != nil {
 			return err
 		}
-		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
+		getter.Downloader, err = download.GetConsistentHashingMode(downloadOpts)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/replicate/pget/pkg/config"
+	"github.com/replicate/pget/pkg/logging"
 )
 
 const UsageTemplate = `
@@ -61,9 +62,11 @@ var hostnameIndexRegexp = regexp.MustCompile(`^[a-z0-9-]*-([0-9]+)[.]`)
 
 func orderCacheHosts(srvs []*net.SRV) ([]string, error) {
 	// loop through to find highest index
+	logger := logging.GetLogger()
 	highestIndex := 0
 	for _, srv := range srvs {
 		cacheIndex, err := cacheIndexFor(srv.Target)
+		logger.Debug().Int("cache_index", cacheIndex).Str("target", srv.Target).Msg("orderCacheHosts")
 		if err != nil {
 			return nil, err
 		}
@@ -71,6 +74,7 @@ func orderCacheHosts(srvs []*net.SRV) ([]string, error) {
 			highestIndex = cacheIndex
 		}
 	}
+	logger.Debug().Int("highest_index", highestIndex).Msg("orderCacheHosts")
 	output := make([]string, highestIndex+1)
 	for _, srv := range srvs {
 		cacheIndex, err := cacheIndexFor(srv.Target)
@@ -81,8 +85,10 @@ func orderCacheHosts(srvs []*net.SRV) ([]string, error) {
 		if srv.Port != 80 {
 			hostname = fmt.Sprintf("%s:%d", hostname, srv.Port)
 		}
+		logger.Debug().Str("hostname", hostname).Int("cache_index", cacheIndex).Msg("orderCacheHosts")
 		output[cacheIndex] = hostname
 	}
+	logger.Debug().Str("output", fmt.Sprintf("%s", output)).Msg("orderCacheHosts")
 	return output, nil
 }
 

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -227,7 +227,9 @@ func (m *ConsistentHashingMode) consistentHashIfNeeded(req *http.Request, start 
 
 			key := fmt.Sprintf("%s#%d", req.URL, slice)
 			hasher := fnv.New64a()
-			hasher.Write([]byte(key))
+			if _, err := hasher.Write([]byte(key)); err != nil {
+				return fmt.Errorf("error calculating hash of key")
+			}
 			// jump is an implementation of Google's Jump Consistent Hash.
 			//
 			// See http://arxiv.org/abs/1406.2294 for details.

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -221,7 +221,7 @@ func (m *ConsistentHashingMode) consistentHashIfNeeded(req *http.Request, start 
 	for _, host := range m.DomainsToCache {
 		if host == req.URL.Host {
 			if start/m.SliceSize != end/m.SliceSize {
-				return fmt.Errorf("Can't make a range request across a slice boundary: %d-%d straddles a slice boundary (slice size is %d)", start, end, m.SliceSize)
+				return fmt.Errorf("can't make a range request across a slice boundary: %d-%d straddles a slice boundary (slice size is %d)", start, end, m.SliceSize)
 			}
 			slice := start / m.SliceSize
 

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -259,6 +259,6 @@ func (m *ConsistentHashingMode) downloadChunk(resp *http.Response, dataSlice []b
 	if n != expectedBytes {
 		return fmt.Errorf("downloaded %d bytes instead of %d for %s", n, expectedBytes, resp.Request.URL.String())
 	}
-	logger.Debug().Int("size", len(dataSlice)).Int("downloaded", n).Bytes("bytes", dataSlice).Msg("downloaded chunk")
+	logger.Debug().Int("size", len(dataSlice)).Int("downloaded", n).Msg("downloaded chunk")
 	return nil
 }

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -25,10 +25,10 @@ type ConsistentHashingMode struct {
 
 func GetConsistentHashingMode(opts Options) (Strategy, error) {
 	if opts.SliceSize == 0 {
-		return nil, fmt.Errorf("Must specify slice size in consistent hashing mode")
+		return nil, fmt.Errorf("must specify slice size in consistent hashing mode")
 	}
 	if opts.Semaphore != nil && opts.MaxConcurrency == 0 {
-		return nil, fmt.Errorf("If you provide a semaphore you must specify MaxConcurrency")
+		return nil, fmt.Errorf("if you provide a semaphore you must specify MaxConcurrency")
 	}
 	client := client.NewHTTPClient(opts.Client)
 	return &ConsistentHashingMode{
@@ -231,6 +231,7 @@ func (m *ConsistentHashingMode) consistentHashIfNeeded(req *http.Request, start 
 			// jump is an implementation of Google's Jump Consistent Hash.
 			//
 			// See http://arxiv.org/abs/1406.2294 for details.
+			logger.Debug().Uint64("hash_sum", hasher.Sum64()).Int("len_cache_hosts", len(m.CacheHosts)).Msg("consistent hashing")
 			cachePodIndex := int(jump.Hash(hasher.Sum64(), len(m.CacheHosts)))
 			cacheHost := m.CacheHosts[cachePodIndex]
 			logger.Debug().Str("cache_key", key).Int64("start", start).Int64("end", end).Int64("slice_size", m.SliceSize).Int("bucket", cachePodIndex).Msg("consistent hashing")


### PR DESCRIPTION
`downloadOpts` is passed by value into download.GetConsistentHashingMode (or any of the get...Mode functions). This means that populating CacheHosts after calling `getConsistentHashingMode` never initialized the values.