### PR TITLE
BUGFIX: Fix tar extraction

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -70,6 +70,11 @@ func GetCommand() *cobra.Command {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	err = viper.BindPFlags(cmd.Flags())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	return cmd
 }
 
@@ -169,6 +174,12 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 
 	getter := pget.Getter{
 		Downloader: download.GetBufferMode(downloadOpts),
+	}
+
+	if viper.GetBool(config.OptExtract) {
+		// TODO: decide what to do when --output is set *and* --extract is set
+		log.Debug().Msg("Tar Extract Enabled")
+		viper.Set(config.OptOutputConsumer, config.ConsumerTarExtractor)
 	}
 
 	if srvName := config.GetCacheSRV(); srvName != "" {

--- a/pkg/extract/tar.go
+++ b/pkg/extract/tar.go
@@ -11,7 +11,15 @@ import (
 	"github.com/replicate/pget/pkg/logging"
 )
 
+type link struct {
+	linkType byte
+	oldName  string
+	newName  string
+}
+
 func TarFile(reader io.Reader, destDir string) error {
+	var links []*link
+
 	startTime := time.Now()
 	tarReader := tar.NewReader(reader)
 	logger := logging.GetLogger()
@@ -49,20 +57,49 @@ func TarFile(reader io.Reader, destDir string) error {
 				targetFile.Close()
 				return err
 			}
-			targetFile.Close()
-		case tar.TypeSymlink:
-			if err := os.Symlink(header.Linkname, target); err != nil {
-				return err
+			if err := targetFile.Close(); err != nil {
+				return fmt.Errorf("error closing file %s: %w", target, err)
 			}
+		case tar.TypeSymlink, tar.TypeLink:
+			// Defer creation of
+			links = append(links, &link{linkType: header.Typeflag, oldName: header.Linkname, newName: target})
 		default:
 			return fmt.Errorf("unsupported file type for %s, typeflag %s", header.Name, string(header.Typeflag))
 		}
 	}
+
+	if err := createLinks(links, destDir); err != nil {
+		return fmt.Errorf("error creating links: %w", err)
+	}
+
 	elapsed := time.Since(startTime).Seconds()
 	logger.Debug().
 		Str("extractor", "tar").
 		Float64("elapsed_time", elapsed).
 		Str("status", "complete").
 		Msg("Extract")
+	return nil
+}
+
+func createLinks(links []*link, destDir string) error {
+	for _, link := range links {
+		targetDir := filepath.Dir(link.newName)
+		if err := os.MkdirAll(targetDir, 0755); err != nil {
+			return err
+		}
+		switch link.linkType {
+		case tar.TypeLink:
+			oldPath := filepath.Join(destDir, link.oldName)
+			if err := os.Link(oldPath, link.newName); err != nil {
+				return fmt.Errorf("error creating hard link from %s to %s: %w", oldPath, link.newName, err)
+			}
+		case tar.TypeSymlink:
+			if err := os.Symlink(link.oldName, link.newName); err != nil {
+				return fmt.Errorf("error creating symlink from %s to %s: %w", link.oldName, link.newName, err)
+			}
+		default:
+			return fmt.Errorf("unsupported link type %s", string(link.linkType))
+		}
+	}
 	return nil
 }

--- a/pkg/extract/tar_test.go
+++ b/pkg/extract/tar_test.go
@@ -1,0 +1,126 @@
+package extract
+
+import (
+	"archive/tar"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateLinks(t *testing.T) {
+	tests := []struct {
+		name          string
+		links         []*link
+		expectedError bool
+	}{
+		{
+			name:  "EmptyLink",
+			links: []*link{},
+		},
+		{
+			name:  "ValidHardLink",
+			links: []*link{{tar.TypeLink, "", "testLinkHard"}},
+		},
+		{
+			name:  "ValidSymlink",
+			links: []*link{{tar.TypeSymlink, "", "testLinkSym"}},
+		},
+		{
+			name:          "InvalidLinkType",
+			links:         []*link{{'!', "", "x"}},
+			expectedError: true,
+		},
+		{
+			name: "ValidMultipleLinks",
+			links: []*link{
+				{tar.TypeLink, "", "testLinkHard"},
+				{tar.TypeSymlink, "", "testLinkSym"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			destDir, err := os.MkdirTemp("./", tt.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Cleanup
+			defer os.RemoveAll(destDir)
+
+			// For hardlink and symlink, create dummy files
+			for _, link := range tt.links {
+				if link.linkType == tar.TypeLink || link.linkType == tar.TypeSymlink {
+					testFile, err := os.CreateTemp(destDir, "test-")
+					if err != nil {
+						t.Fatalf("Test failed, could not create test file: %v", err)
+					}
+					_ = testFile.Close()
+					link.oldName = filepath.Base(testFile.Name())
+					link.newName = filepath.Join(destDir, link.newName)
+				}
+			}
+
+			err = createLinks(tt.links, destDir)
+
+			// Validation
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				for _, link := range tt.links {
+					oldPath := filepath.Join(destDir, link.oldName)
+					if link.linkType == tar.TypeSymlink {
+						assertSymlinkTarget(t, oldPath, link.newName)
+					} else if link.linkType == tar.TypeLink {
+						assertHardLinkTarget(t, oldPath, link.newName)
+					} else {
+						t.Fatal("Invalid link type")
+					}
+				}
+			}
+
+		})
+	}
+}
+
+func assertHardLinkTarget(t *testing.T, oldName, newName string) {
+	fileStat, err := os.Stat(oldName)
+	if !assert.NoError(t, err) {
+		t.Fatal("Test failed, could not stat test-created file", err)
+	}
+	linkStat, err := os.Lstat(newName)
+	if !assert.NoError(t, err) {
+		t.Fatalf("Test failed, could not stat link %s: %v", newName, err)
+	}
+	targetStat, err := os.Stat(newName)
+	if !assert.NoError(t, err) {
+		t.Fatalf("Test failed, could not stat link %s: %v", newName, err)
+	}
+	assert.True(t, linkStat.Mode()&os.ModeSymlink == 0)
+	assert.Equal(t, fileStat.Sys().(*syscall.Stat_t).Ino, targetStat.Sys().(*syscall.Stat_t).Ino)
+}
+
+func assertSymlinkTarget(t *testing.T, oldName, newName string) {
+	fileStat, err := os.Stat(oldName)
+	if !assert.NoError(t, err) {
+		t.Fatal("Test failed, could not stat test-created file", err)
+	}
+	linkStat, err := os.Lstat(newName)
+	if !assert.NoError(t, err) {
+		t.Fatalf("Test failed, could not stat link %s: %v", newName, err)
+	}
+	assert.True(t, linkStat.Mode()&os.ModeSymlink != 0)
+	// os.Stat follows symlinks
+	realTarget, err := os.Stat(newName)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	assert.Equal(t, fileStat.Sys().(*syscall.Stat_t).Ino,
+		realTarget.Sys().(*syscall.Stat_t).Ino)
+}


### PR DESCRIPTION
Fix tar extraction:
* Make -x function again for rootCMD
* Properly handle hard-links in tar files.
  * implement testing for the tar extraction code

Closes: #87
Closes: #86