### PR TITLE
BUGFIX: ensure --resolve and -v work in multifile mode

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -47,7 +47,7 @@ func GetCommand() *cobra.Command {
 		Use:   "pget [flags] <url> <dest>",
 		Short: "pget",
 		Long:  rootLongDesc,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := config.PersistentStartupProcessFlags(); err != nil {
 				return err
 			}


### PR DESCRIPTION
rootCMD was changed (erroneously) to use a PreRunE not a PersistentPreRunE that caused --resolve and -v to be properly handled. This meant multifile could not rely on --resolve or -v for anything useful (they were never "set" from multifile's perspective)

Closes: #95