### PR TITLE
Cleanup

### DIFF
--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -110,11 +110,18 @@ func multifileExecute(ctx context.Context, manifest manifest) error {
 		return err
 	}
 
+	// Get the resolution overrides
+	resolveOverrides, err := config.ResolveOverridesToMap(viper.GetStringSlice(config.OptResolve))
+	if err != nil {
+		return fmt.Errorf("error parsing resolve overrides: %w", err)
+	}
+
 	clientOpts := client.Options{
-		MaxConnPerHost: viper.GetInt(config.OptMaxConnPerHost),
-		ForceHTTP2:     viper.GetBool(config.OptForceHTTP2),
-		MaxRetries:     viper.GetInt(config.OptRetries),
-		ConnectTimeout: viper.GetDuration(config.OptConnTimeout),
+		MaxConnPerHost:   viper.GetInt(config.OptMaxConnPerHost),
+		ForceHTTP2:       viper.GetBool(config.OptForceHTTP2),
+		MaxRetries:       viper.GetInt(config.OptRetries),
+		ConnectTimeout:   viper.GetDuration(config.OptConnTimeout),
+		ResolveOverrides: resolveOverrides,
 	}
 	downloadOpts := download.Options{
 		MaxConcurrency: viper.GetInt(config.OptConcurrency),

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -158,11 +158,16 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 		return fmt.Errorf("error parsing minimum chunk size: %w", err)
 	}
 
+	resolveOverrides, err := config.ResolveOverridesToMap(viper.GetStringSlice(config.OptResolve))
+	if err != nil {
+		return fmt.Errorf("error parsing resolve overrides: %w", err)
+	}
 	clientOpts := client.Options{
-		ForceHTTP2:     viper.GetBool(config.OptForceHTTP2),
-		MaxRetries:     viper.GetInt(config.OptRetries),
-		ConnectTimeout: viper.GetDuration(config.OptConnTimeout),
-		MaxConnPerHost: viper.GetInt(config.OptMaxConnPerHost),
+		ForceHTTP2:       viper.GetBool(config.OptForceHTTP2),
+		MaxRetries:       viper.GetInt(config.OptRetries),
+		ConnectTimeout:   viper.GetDuration(config.OptConnTimeout),
+		MaxConnPerHost:   viper.GetInt(config.OptMaxConnPerHost),
+		ResolveOverrides: resolveOverrides,
 	}
 
 	downloadOpts := download.Options{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -138,9 +138,6 @@ type transportDialer struct {
 
 func (d *transportDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	logger := logging.GetLogger()
-	if d.DNSOverrideMap == nil {
-		return d.Dialer.DialContext(ctx, network, addr)
-	}
 	if addrOverride := d.DNSOverrideMap[addr]; addrOverride != "" {
 		logger.Debug().Str("addr", addr).Str("override", addrOverride).Msg("DNS Override")
 		addr = addrOverride

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,7 +105,7 @@ func ResolveOverridesToMap(resolveOverrides []string) (map[string]string, error)
 	logger := logging.GetLogger()
 	resolveOverrideMap := make(map[string]string)
 
-	if resolveOverrides == nil || len(resolveOverrides) == 0 {
+	if len(resolveOverrides) == 0 {
 		return nil, nil
 	}
 

--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -123,11 +123,11 @@ func (m *BufferMode) fileToBuffer(ctx context.Context, url string) (*bytes.Buffe
 		if i == numChunks-1 {
 			end = fileSize - 1
 		}
-		resp, err := m.doRequest(ctx, start, end, trueURL)
-		if err != nil {
-			return nil, -1, err
-		}
 		errGroup.Go(func() error {
+			resp, err := m.doRequest(ctx, start, end, trueURL)
+			if err != nil {
+				return err
+			}
 			return m.downloadChunk(resp, data[start:end+1])
 		})
 	}


### PR DESCRIPTION
* Eliminate global host resolution map - generally less fragile avoiding a global causing behavior changes.
  * Resolution overrides are now passed down in the client options.
 
* Make the same fix made to consistent-hashing and move the .doRequest to within the go routine preventing blocking the main thread for no good reason.