### PR TITLE
Implement consistent-hashing for multifile

### DIFF
--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -123,6 +123,21 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 		Consumer:   consumer,
 	}
 
+	// TODO DRY this
+	if srvName := config.GetCacheSRV(); srvName != "" {
+		downloadOpts.SliceSize = 512 * humanize.MiByte
+		// FIXME: make this a config option
+		downloadOpts.DomainsToCache = []string{"weights.replicate.delivery"}
+		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
+		if err != nil {
+			return err
+		}
+		getter.Downloader, err = download.GetConsistentHashingMode(downloadOpts)
+		if err != nil {
+			return err
+		}
+	}
+
 	totalFileSize, elapsedTime, err := getter.DownloadFiles(ctx, manifest)
 	if err != nil {
 		return err

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -193,6 +193,7 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 		viper.Set(config.OptOutputConsumer, config.ConsumerTarExtractor)
 	}
 
+	// TODO DRY this
 	if srvName := config.GetCacheSRV(); srvName != "" {
 		downloadOpts.SliceSize = 512 * humanize.MiByte
 		// FIXME: make this a config option


### PR DESCRIPTION
Multifile MUST support consistent-hashing mode. This is a copy/paste from the rootCMD override of the getter.Downloader; we should DRY this eventually.

Closes: #98