### PR TITLE
BUGFIX: Multifile did not respect/utilize the consumer setting cli option

### DIFF
--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -83,6 +83,9 @@ func multifilePreRunE(cmd *cobra.Command, args []string) error {
 	if viper.GetBool(config.OptExtract) {
 		return fmt.Errorf("cannot use --extract with multifile mode")
 	}
+	if viper.GetString(config.OptOutputConsumer) == config.ConsumerTarExtractor {
+		return fmt.Errorf("cannot use --output-consumer tar-extractor with multifile mode")
+	}
 	return nil
 }
 
@@ -121,8 +124,15 @@ func multifileExecute(ctx context.Context, manifest manifest) error {
 		MinChunkSize:   int64(minChunkSize),
 		Client:         clientOpts,
 	}
+
+	consumer, err := config.GetConsumer()
+	if err != nil {
+		return fmt.Errorf("error getting consumer: %w", err)
+	}
+
 	getter := &pget.Getter{
 		Downloader: download.GetBufferMode(downloadOpts),
+		Consumer:   consumer,
 	}
 
 	metrics := &downloadMetrics{

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -172,8 +172,14 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 		Semaphore:      semaphore.NewWeighted(int64(viper.GetInt(config.OptConcurrency))),
 	}
 
+	consumer, err := config.GetConsumer()
+	if err != nil {
+		return err
+	}
+
 	getter := pget.Getter{
 		Downloader: download.GetBufferMode(downloadOpts),
+		Consumer:   consumer,
 	}
 
 	if viper.GetBool(config.OptExtract) {
@@ -195,13 +201,6 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 			return err
 		}
 	}
-
-	consumer, err := config.GetConsumer()
-	if err != nil {
-		return err
-	}
-
-	getter.Consumer = consumer
 
 	_, _, err = getter.DownloadFile(ctx, urlString, dest)
 	return err


### PR DESCRIPTION
This change allows multifile to specify consumer(s). This is useful for things such as utilizing multifile with a null consumer for testing.

Closes: #100