### PR TITLE
BUGFIX: example in -x is incorrect

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -56,7 +56,7 @@ func GetCommand() *cobra.Command {
 		PreRun:  rootCmdPreRun,
 		RunE:    runRootCMD,
 		Args:    cobra.ExactArgs(2),
-		Example: `  pget https://example.com/file.tar.gz file.tar.gz`,
+		Example: `  pget https://example.com/file.tar ./target-dir`,
 	}
 	cmd.Flags().BoolP(config.OptExtract, "x", false, "OptExtract archive after download")
 	cmd.SetUsageTemplate(cli.UsageTemplate)


### PR DESCRIPTION
We do not support .tar.gz fix the help to be explicit about what we support.

Closes: #113