### PR TITLE
Make Domains to Cache configurable

### DIFF
--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -138,8 +138,8 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 	// TODO DRY this
 	if srvName := config.GetCacheSRV(); srvName != "" {
 		downloadOpts.SliceSize = 500 * humanize.MiByte
-		// FIXME: make this a config option
-		downloadOpts.DomainsToCache = []string{"weights.replicate.delivery"}
+		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
+		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
 		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
 		if err != nil {
 			return err

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -242,7 +242,8 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 	if srvName := config.GetCacheSRV(); srvName != "" {
 		downloadOpts.SliceSize = 500 * humanize.MiByte
 		// FIXME: make this a config option
-		downloadOpts.DomainsToCache = []string{"weights.replicate.delivery"}
+		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
+		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
 		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
 		if err != nil {
 			return err

--- a/pkg/config/optnames.go
+++ b/pkg/config/optnames.go
@@ -1,12 +1,15 @@
 package config
 
 const (
-	// these two options are a massive hack. They're only availabe via
+	// these options are a massive hack. They're only availabe via
 	// envvar, not command line
 	OptCacheNodesSRVNameByHostCIDR = "cache-nodes-srv-name-by-host-cidr"
+	OptCacheNodesSRVName           = "cache-nodes-srv-name"
+	OptCacheURIPrefixes            = "cache-uri-prefixes"
+	OptCacheUsePathProxy           = "cache-use-path-proxy"
 	OptHostIP                      = "host-ip"
 
-	OptCacheNodesSRVName  = "cache-nodes-srv-name"
+	// Normal options with CLI arguments
 	OptConcurrency        = "concurrency"
 	OptConnTimeout        = "connect-timeout"
 	OptExtract            = "extract"

--- a/pkg/download/consistent_hashing_test.go
+++ b/pkg/download/consistent_hashing_test.go
@@ -2,6 +2,7 @@ package download_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -161,6 +162,18 @@ var chTestCases = []chTestCase{
 	},
 }
 
+func makeCacheableURIPrefixes(uris ...string) map[string][]*url.URL {
+	m := make(map[string][]*url.URL)
+	for _, uri := range uris {
+		parsed, err := url.Parse(uri)
+		if err != nil {
+			panic(err)
+		}
+		m[parsed.Host] = append(m[parsed.Host], parsed)
+	}
+	return m
+}
+
 func TestConsistentHashing(t *testing.T) {
 	hostnames := make([]string, len(testFSes))
 	for i, fs := range testFSes {
@@ -174,25 +187,76 @@ func TestConsistentHashing(t *testing.T) {
 	for _, tc := range chTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := download.Options{
-				Client:         client.Options{},
-				MaxConcurrency: tc.concurrency,
-				MinChunkSize:   tc.minChunkSize,
-				CacheHosts:     hostnames[0:tc.numCacheHosts],
-				DomainsToCache: []string{"test.replicate.com"},
-				SliceSize:      tc.sliceSize,
+				Client:               client.Options{},
+				MaxConcurrency:       tc.concurrency,
+				MinChunkSize:         tc.minChunkSize,
+				CacheHosts:           hostnames[0:tc.numCacheHosts],
+				CacheableURIPrefixes: makeCacheableURIPrefixes("http://test.replicate.com"),
+				SliceSize:            tc.sliceSize,
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
 			strategy, err := download.GetConsistentHashingMode(opts)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.numCacheHosts, len(strategy.Options.CacheHosts))
 			reader, _, err := strategy.Fetch(ctx, "http://test.replicate.com/hello.txt")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			bytes, err := io.ReadAll(reader)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedOutput, string(bytes))
+		})
+	}
+}
+
+func validatePathPrefixMiddleware(t *testing.T, next http.Handler, hostname string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, hostname, r.Host)
+		hostPfx := fmt.Sprintf("/%s", hostname)
+		assert.True(t, strings.HasPrefix(r.URL.Path, hostPfx))
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, hostPfx)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func TestConsistentHashingPathBased(t *testing.T) {
+	var hostname = "test.replicate.com"
+	hostnames := make([]string, len(testFSes))
+	for i, fs := range testFSes {
+		validatePathPrefixAndStrip := validatePathPrefixMiddleware(t, http.FileServer(http.FS(fs)), hostname)
+		ts := httptest.NewServer(validatePathPrefixAndStrip)
+		defer ts.Close()
+		url, err := url.Parse(ts.URL)
+		require.NoError(t, err)
+		hostnames[i] = url.Host
+	}
+
+	for _, tc := range chTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := download.Options{
+				Client:               client.Options{},
+				MaxConcurrency:       tc.concurrency,
+				MinChunkSize:         tc.minChunkSize,
+				CacheHosts:           hostnames[0:tc.numCacheHosts],
+				CacheableURIPrefixes: makeCacheableURIPrefixes(fmt.Sprintf("http://%s", hostname)),
+				CacheUsePathProxy:    true,
+				SliceSize:            tc.sliceSize,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			strategy, err := download.GetConsistentHashingMode(opts)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.numCacheHosts, len(strategy.Options.CacheHosts))
+			reader, _, err := strategy.Fetch(ctx, fmt.Sprintf("http://%s/hello.txt", hostname))
+			require.NoError(t, err)
+			bytes, err := io.ReadAll(reader)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedOutput, string(bytes))
 		})
@@ -212,24 +276,24 @@ func TestConsistentHashRetries(t *testing.T) {
 	hostnames[0] = "localhost:1"
 
 	opts := download.Options{
-		Client:         client.Options{},
-		MaxConcurrency: 8,
-		MinChunkSize:   1,
-		CacheHosts:     hostnames,
-		DomainsToCache: []string{"fake.replicate.delivery"},
-		SliceSize:      1,
+		Client:               client.Options{},
+		MaxConcurrency:       8,
+		MinChunkSize:         1,
+		CacheHosts:           hostnames,
+		CacheableURIPrefixes: makeCacheableURIPrefixes("http://fake.replicate.delivery"),
+		SliceSize:            1,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	strategy, err := download.GetConsistentHashingMode(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reader, _, err := strategy.Fetch(ctx, "http://fake.replicate.delivery/hello.txt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	bytes, err := io.ReadAll(reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// with a functional hostnames[0], we'd see 0344760706165500, but instead we
 	// should fall back to this. Note that each 0 value has been changed to a
@@ -251,24 +315,24 @@ func TestConsistentHashRetriesTwoHosts(t *testing.T) {
 	hostnames[1] = "localhost:1"
 
 	opts := download.Options{
-		Client:         client.Options{},
-		MaxConcurrency: 8,
-		MinChunkSize:   1,
-		CacheHosts:     hostnames,
-		DomainsToCache: []string{"testing.replicate.delivery"},
-		SliceSize:      1,
+		Client:               client.Options{},
+		MaxConcurrency:       8,
+		MinChunkSize:         1,
+		CacheHosts:           hostnames,
+		CacheableURIPrefixes: makeCacheableURIPrefixes("http://testing.replicate.delivery"),
+		SliceSize:            1,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	strategy, err := download.GetConsistentHashingMode(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	reader, _, err := strategy.Fetch(ctx, "http://testing.replicate.delivery/hello.txt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	bytes, err := io.ReadAll(reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "0000000000000000", string(bytes))
 }
@@ -278,12 +342,12 @@ func TestConsistentHashingHasFallback(t *testing.T) {
 	defer server.Close()
 
 	opts := download.Options{
-		Client:         client.Options{},
-		MaxConcurrency: 8,
-		MinChunkSize:   2,
-		CacheHosts:     []string{},
-		DomainsToCache: []string{"fake.replicate.delivery"},
-		SliceSize:      3,
+		Client:               client.Options{},
+		MaxConcurrency:       8,
+		MinChunkSize:         2,
+		CacheHosts:           []string{},
+		CacheableURIPrefixes: makeCacheableURIPrefixes("http://fake.replicate.delivery"),
+		SliceSize:            3,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -297,7 +361,7 @@ func TestConsistentHashingHasFallback(t *testing.T) {
 	reader, _, err := strategy.Fetch(ctx, urlString)
 	require.NoError(t, err)
 	bytes, err := io.ReadAll(reader)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "0000000000000000", string(bytes))
 }
@@ -373,19 +437,19 @@ func TestConsistentHashingFileFallback(t *testing.T) {
 
 			url, _ := url.Parse(server.URL)
 			opts := download.Options{
-				Client:         client.Options{},
-				MaxConcurrency: 8,
-				MinChunkSize:   2,
-				CacheHosts:     []string{url.Host},
-				DomainsToCache: []string{"fake.replicate.delivery"},
-				SliceSize:      3,
+				Client:               client.Options{},
+				MaxConcurrency:       8,
+				MinChunkSize:         2,
+				CacheHosts:           []string{url.Host},
+				CacheableURIPrefixes: makeCacheableURIPrefixes("http://fake.replicate.delivery"),
+				SliceSize:            3,
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
 			strategy, err := download.GetConsistentHashingMode(opts)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			fallbackStrategy := &testStrategy{}
 			strategy.FallbackStrategy = fallbackStrategy
@@ -435,19 +499,19 @@ func TestConsistentHashingChunkFallback(t *testing.T) {
 
 			url, _ := url.Parse(server.URL)
 			opts := download.Options{
-				Client:         client.Options{},
-				MaxConcurrency: 8,
-				MinChunkSize:   3,
-				CacheHosts:     []string{url.Host},
-				DomainsToCache: []string{"fake.replicate.delivery"},
-				SliceSize:      3,
+				Client:               client.Options{},
+				MaxConcurrency:       8,
+				MinChunkSize:         3,
+				CacheHosts:           []string{url.Host},
+				CacheableURIPrefixes: makeCacheableURIPrefixes("http://fake.replicate.delivery"),
+				SliceSize:            3,
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
 			strategy, err := download.GetConsistentHashingMode(opts)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			fallbackStrategy := &testStrategy{}
 			strategy.FallbackStrategy = fallbackStrategy

--- a/pkg/download/options.go
+++ b/pkg/download/options.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"net/url"
 	"runtime"
 
 	"github.com/replicate/pget/pkg/client"
@@ -20,9 +21,15 @@ type Options struct {
 	MinChunkSize int64
 	Client       client.Options
 
-	// DomainsToCache is an allowlist of domains which may be routed via a
-	// pull-through cache
-	DomainsToCache []string
+	// CacheableURIPrefixes is an allowlist of domains+path-prefixes which may
+	// be routed via a pull-through cache
+	CacheableURIPrefixes map[string][]*url.URL
+
+	// CacheUsePathProxy is a flag to indicate whether to use the path proxy mechanism or the host-based mechanism
+	// The default is to use the host-based mechanism, the path proxy mechanism is used when this flag is set to true
+	// and involves prepending the host to the path of the request to the cache. In both cases the Hosts header is
+	// sent to the cache.
+	CacheUsePathProxy bool
 
 	// CacheHosts is a slice of hostnames to use as pull-through caches.
 	// The ordering is significant and will be used with the consistent


### PR DESCRIPTION
Make domains to cache configurable via ENV. The implements the framework to also limit caching to certain prefixes to the path.