### PR TITLE
Improve PIDFile locking

### DIFF
--- a/pkg/cli/pid.go
+++ b/pkg/cli/pid.go
@@ -3,52 +3,80 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"syscall"
+	"time"
 
 	"github.com/replicate/pget/pkg/logging"
 )
 
 type PIDFile struct {
+	Path string
 	file *os.File
 	fd   int
 }
 
-func NewPIDFile(path string) (*PIDFile, error) {
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+func (p *PIDFile) tryCreateLockFile(path string) (*os.File, error) {
+	logger := logging.GetLogger()
+
+	lockedFile, err := os.OpenFile(p.Path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
+
 	if err != nil {
-		return nil, err
+		if errors.Is(err, os.ErrExist) {
+			logger.Warn().
+				Err(err).
+				Str("warn_message", "Another pget process may be running. Use 'pget multifile' to download multiple files in parallel.").
+				Msg("Waiting on Lock")
+		} else {
+			return nil, err
+		}
+
 	}
-	return &PIDFile{file: file, fd: int(file.Fd())}, nil
+	return lockedFile, nil
+}
+
+func (p *PIDFile) acquireLock() error {
+	logger := logging.GetLogger()
+	var lockedFile *os.File
+	var err error
+	for {
+		logger.Debug().Str("path", p.Path).Msg("Attempting Lock Acquire")
+		lockedFile, err = p.tryCreateLockFile(p.Path)
+		if err != nil {
+			// TODO: consider adding a validation to ensure that the PID in the lock file is still running
+			// and if not, remove the lock file and try again
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		p.file = lockedFile
+		p.fd = int(lockedFile.Fd())
+		logger.Debug().Str("path", p.Path).Msg("Lock Acquired")
+		return nil
+	}
 }
 
 func (p *PIDFile) Acquire() error {
-	logger := logging.GetLogger()
 	funcs := []func() error{
-		func() error {
-			logger.Debug().Str("blocking_lock_acquire", "false").Msg("Waiting on Lock")
-			err := syscall.Flock(p.fd, syscall.LOCK_EX|syscall.LOCK_NB)
-			if err != nil {
-				logger.Warn().
-					Err(err).
-					Str("warn_message", "Another pget process may be running, use 'pget multifile' to download multiple files in parallel").
-					Msg("Waiting on Lock")
-				logger.Debug().Str("blocking_lock_acquire", "true").Msg("Waiting on Lock")
-				err = syscall.Flock(p.fd, syscall.LOCK_EX)
-			}
-			return err
-		},
+		p.acquireLock,
 		p.writePID,
 		p.file.Sync,
 	}
 	return p.executeFuncs(funcs)
 }
 
+func (p *PIDFile) Remove() error {
+	err := os.Remove(p.Path)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
 func (p *PIDFile) Release() error {
 	funcs := []func() error{
-		func() error { return syscall.Flock(p.fd, syscall.LOCK_UN) },
 		p.file.Close,
+		p.Remove,
 	}
 	return p.executeFuncs(funcs)
 }


### PR DESCRIPTION
Instead of using flock, use exclusive create. This method has the blind spot that if the pid file has been left after a failed run, or crashed process, it is not possible to automatically clean up.

Likely it will make sense to add in an addtinal check "does pid exist from file if file exists" and "verify if pid is a pget process". If it's a stale pid we can safely remove and try the O_EXCL create...