### PR TITLE
WIP: Implement Aliasing

### DIFF
--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -139,6 +139,7 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 	if srvName := config.GetCacheSRV(); srvName != "" {
 		downloadOpts.SliceSize = 500 * humanize.MiByte
 		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
+		downloadOpts.CacheableURIPrefixAliases = config.GetURIAliases(downloadOpts.CacheableURIPrefixes)
 		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
 		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
 		if err != nil {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -243,6 +243,7 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 		downloadOpts.SliceSize = 500 * humanize.MiByte
 		// FIXME: make this a config option
 		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
+		downloadOpts.CacheableURIPrefixAliases = config.GetURIAliases(downloadOpts.CacheableURIPrefixes)
 		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
 		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
 		if err != nil {

--- a/pkg/config/optnames.go
+++ b/pkg/config/optnames.go
@@ -6,6 +6,7 @@ const (
 	OptCacheNodesSRVNameByHostCIDR = "cache-nodes-srv-name-by-host-cidr"
 	OptCacheNodesSRVName           = "cache-nodes-srv-name"
 	OptCacheURIPrefixes            = "cache-uri-prefixes"
+	OptCacheURIPrefixAliases       = "cache-uri-prefix-aliases"
 	OptCacheUsePathProxy           = "cache-use-path-proxy"
 	OptHostIP                      = "host-ip"
 

--- a/pkg/download/options.go
+++ b/pkg/download/options.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/replicate/pget/pkg/client"
+	"github.com/replicate/pget/pkg/config"
 )
 
 type Options struct {
@@ -24,6 +25,9 @@ type Options struct {
 	// CacheableURIPrefixes is an allowlist of domains+path-prefixes which may
 	// be routed via a pull-through cache
 	CacheableURIPrefixes map[string][]*url.URL
+
+	// CacheableURIPrefixAliases is a map of alias to the associated target URI prefix
+	CacheableURIPrefixAliases map[string][]config.CacheableURIPrefixAlias
 
 	// CacheUsePathProxy is a flag to indicate whether to use the path proxy mechanism or the host-based mechanism
 	// The default is to use the host-based mechanism, the path proxy mechanism is used when this flag is set to true


### PR DESCRIPTION
Implement aliasing, rewriting a URI Prefix to a target. This can be used to maintain the same consistent hashing jump profile for domains that map to the same cache-keys.

Example:

Target: cdn.example.com/weights
Alias:  origin.domain.org/llm-designer-name

In the above example it would be desireable to rewrite the alias to Target. Even though it is possible for the cache server should consider these equivalent due to it's internal config, it will result in different Jump hashing and therefore more content needing to be cached across more nodes in the consistent-hashing mode.

This commit does not implment additional testing to be completed in a follow-on commit.