### PR TITLE
fix homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you're using macOS, you can install PGet with Homebrew:
 
 ```console
 brew tap replicate/tap
-brew install pget
+brew install replicate/tap/pget
 ```
 
 Or you can build from source and install it with these commands


### PR DESCRIPTION
Running `brew install pget` will install the [code-hex version of `pget`](https://github.com/Code-Hex/pget), even if you've tapped the replicate thing first.

This PR updates the docs to explicitly install from the replicate tap.

Works on my machine:

```
$ brew tap replicate/tap


$ which pget
pget not found


$ brew install pget
==> Downloading https://formulae.brew.sh/api/formula.jws.json
########################################################################################################################################################################### 100.0%
==> Downloading https://formulae.brew.sh/api/cask.jws.json
########################################################################################################################################################################### 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/pget/manifests/0.2.1
########################################################################################################################################################################### 100.0%
==> Fetching pget
==> Downloading https://ghcr.io/v2/homebrew/core/pget/blobs/sha256:48b2b055afe66da789fc85f5f613bb9ea1af341f799c5ef540e9bfa889fad9ce
...


$ pget --version
unknown flag `version'
Pget 0.2.1, The fastest file download client
Usage: pget [options] URL
  Options:
  -h,  --help                   print usage and exit
  -p,  --procs <num>            the number of connections for a single URL (default 1)
  -o,  --output <filename>      output file to <filename>
  -t,  --timeout <seconds>      timeout of checking request in seconds (default 10s)
  -u,  --user-agent <agent>     identify as <agent>
  -r,  --referer <referer>      identify as <referer>
  --check-update                check if there is update available
  --trace                       display detail error messages
Error:
  unknown flag `version'


$ brew uninstall pget
Uninstalling /opt/homebrew/Cellar/pget/0.2.1... (5 files, 6.9MB)


$ pget
pget command not found.



$ brew install replicate/pget
Warning: No available formula with the name "replicate/pget". Did you mean replicate/tap/pget?


$ brew install replicate/tap/pget
==> Fetching dependencies for replicate/tap/pget: go
...
==> Fetching replicate/tap/pget
==> Downloading https://github.com/replicate/pget/archive/refs/tags/v0.3.3.tar.gz
==> Downloading from https://codeload.github.com/replicate/pget/tar.gz/refs/tags/v0.3.3
...



$ pget
Error: accepts 2 arg(s), received 0

Usage:
pget [flags] <url> <dest>
pget [command]

Examples:
  pget https://example.com/file.tar.gz file.tar.gz

Available Commands:
completion  Generate the autocompletion script for the specified shell
multifile   download files from a manifest file in parallel
version     print version and build information

Flags:
  -c, --concurrency int             Maximum number of concurrent downloads/maximum number of chunks for a given file (default 32)
      --connect-timeout duration    Timeout for establishing a connection, format is <number><unit>, e.g. 10s (default 5s)
  -x, --extract                     OptExtract archive after download
  -f, --force                       OptForce download, overwriting existing file
  -h, --help                        help for pget
      --log-level string            Log level (debug, info, warn, error) (default "info")
  -m, --minimum-chunk-size string   Minimum chunk size (in bytes) to use when downloading a file (e.g. 10M) (default "16M")
      --resolve strings             OptResolve hostnames to specific IPs
  -r, --retries int                 Number of retries when attempting to retrieve a file (default 5)
  -v, --verbose                     OptVerbose mode (equivalent to --log-level debug)

Use "pget [command] --help" for more information about a command.

```