### PR TITLE
slice boundary bug

### DIFF
--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -77,6 +77,7 @@ func (m *BufferMode) Fetch(ctx context.Context, url string) (io.Reader, int64, e
 			defer br.done()
 			firstChunkResp, err := m.DoRequest(ctx, 0, m.minChunkSize()-1, url)
 			if err != nil {
+				br.err = err
 				firstReqResultCh <- firstReqResult{err: err}
 				return err
 			}
@@ -159,6 +160,7 @@ func (m *BufferMode) Fetch(ctx context.Context, url string) (io.Reader, int64, e
 				defer br.done()
 				resp, err := m.DoRequest(ctx, start, end, trueURL)
 				if err != nil {
+					br.err = err
 					return err
 				}
 				defer resp.Body.Close()

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -191,12 +191,12 @@ func (m *ConsistentHashingMode) Fetch(ctx context.Context, urlString string) (io
 			}
 			startFrom := m.SliceSize * int64(slice)
 			sliceSize := m.SliceSize
+			if slice == int(totalSlices)-1 {
+				sliceSize = (fileSize-1)%m.SliceSize + 1
+			}
 			if slice == 0 {
 				startFrom = m.minChunkSize()
 				sliceSize = sliceSize - m.minChunkSize()
-			}
-			if slice == int(totalSlices)-1 {
-				sliceSize = (fileSize-1)%m.SliceSize + 1
 			}
 			if sliceSize/numChunks < m.minChunkSize() {
 				// reset numChunks to respect minChunkSize

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -112,6 +112,7 @@ func (m *ConsistentHashingMode) Fetch(ctx context.Context, urlString string) (io
 			defer br.done()
 			firstChunkResp, err := m.DoRequest(ctx, 0, m.minChunkSize()-1, urlString)
 			if err != nil {
+				br.err = err
 				firstReqResultCh <- firstReqResult{err: err}
 				return err
 			}
@@ -232,6 +233,7 @@ func (m *ConsistentHashingMode) Fetch(ctx context.Context, urlString string) (io
 							resp, err = m.FallbackStrategy.DoRequest(ctx, chunkStart, chunkEnd, urlString)
 						}
 						if err != nil {
+							br.err = err
 							return err
 						}
 					}
@@ -297,7 +299,7 @@ func (m *ConsistentHashingMode) DoRequest(ctx context.Context, start, end int64,
 func (m *ConsistentHashingMode) rewriteRequestToCacheHost(req *http.Request, start int64, end int64, previousPodIndexes ...int) (int, error) {
 	logger := logging.GetLogger()
 	if start/m.SliceSize != end/m.SliceSize {
-		return 0, fmt.Errorf("can't make a range request across a slice boundary: %d-%d straddles a slice boundary (slice size is %d)", start, end, m.SliceSize)
+		return 0, fmt.Errorf("Internal error: can't make a range request across a slice boundary: %d-%d straddles a slice boundary (slice size is %d)", start, end, m.SliceSize)
 	}
 	slice := start / m.SliceSize
 

--- a/pkg/download/consistent_hashing_test.go
+++ b/pkg/download/consistent_hashing_test.go
@@ -145,6 +145,14 @@ var chTestCases = []chTestCase{
 		expectedOutput: "3333333333333333",
 	},
 	{
+		name:           "test when minChunkSize slightly below file size",
+		concurrency:    4,
+		sliceSize:      16,
+		numCacheHosts:  8,
+		minChunkSize:   15,
+		expectedOutput: "3333333333333333",
+	},
+	{
 		name:           "test when minChunkSize > file size",
 		concurrency:    4,
 		sliceSize:      24,


### PR DESCRIPTION
We have a bug where:

- the file to download fits inside a single slice
- it takes N chunks to download
- N full chunks is larger than a slice

This was causing a logic error, but our error handling was failing to propagate the error correctly, so it manifested to the user as the last request not being made and the file being truncated.  In extract mode, this resulted in an unexpected EOF.

This PR fixes the error propagation so it would have been clearer that this was an internal pget bug, and it also fixes the bug.

This is a short PR but it's still worth reviewing commit-by-commit.