### PR TITLE
Restore default cacheable URL prefix

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,10 @@ const (
 	ConsumerNull         = "null"
 )
 
+var (
+	DefaultCacheURIPrefixes = []string{"https://weights.replicate.delivery"}
+)
+
 type ConsistentHashingStrategy struct{}
 
 var ConsistentHashingStrategyKey ConsistentHashingStrategy
@@ -194,6 +198,10 @@ func CacheableURIPrefixes() map[string][]*url.URL {
 	result := make(map[string][]*url.URL)
 
 	URIs := viper.GetStringSlice(OptCacheURIPrefixes)
+	if len(URIs) == 0 {
+		URIs = DefaultCacheURIPrefixes
+	}
+
 	for _, uri := range URIs {
 		parsed, err := url.Parse(uri)
 		if err != nil || parsed.Host == "" || parsed.Scheme == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -78,8 +78,10 @@ func TestCacheableURIPrefixes(t *testing.T) {
 		expected map[string][]*url.URL
 	}{
 		{
-			name:     "empty",
-			expected: map[string][]*url.URL{},
+			name: "default",
+			expected: map[string][]*url.URL{
+				"weights.replicate.delivery": helperUrlParse(t, "https://weights.replicate.delivery"),
+			},
 		},
 		{
 			name:     "single",


### PR DESCRIPTION
This restores to the status quo before #127.