### PR TITLE
Fix Consistent-Hash Memory Leak

### DIFF
--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -213,7 +213,7 @@ func (m *ConsistentHashingMode) Fetch(ctx context.Context, urlString string) (io
 				chunkStart := startFrom
 				chunkEnd := startFrom + chunkSize - 1
 
-				br := newBufferedReader(m.minChunkSize())
+				br := newBufferedReader(chunkSize)
 				readersCh <- br
 				m.sem.Go(func() error {
 					defer br.done()


### PR DESCRIPTION
Based upon how bytes.Buffer works, it will continue to grow the underlying slice while reading data and add additional headroom to ensure that there is enough space, this means that when we allocate the bytes.Buffer to a small amount (minChunkSize()) the growth occurs regularly on any reads that push beyond the initial slice. Even at a minChunkSize of ~150M, when downloading SDXL we end up with a balloon of an additional ~10GiB allocated.

This has resulted in SigKill (OOMKILL) of pget in lower-ram systems. This does not address the overall memory allocation requirements of pget, which still generally encompasses the entire file size. An additional pass will need to be done to ensure the consumer can read and the buffer can be GC'd to minimize overall memory allocation.

This only surfaced in consistent-hash mode as buffer mode was properly setting the buffered reader to the chunkSize by calculating end - start +1. Consistent Hash only used m.minChunkSize() which is appropriate for the initial chunk download, but inappropriate for the subsequent larger chunks.

This particular memory leak would not affect files or file chunks that are smaller than the m.minChunkSize() value.

Closes: #150