### PR TITLE
Remove Path-Proxy Code Paths

### DIFF
--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -139,7 +139,6 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 	if srvName := config.GetCacheSRV(); srvName != "" {
 		downloadOpts.SliceSize = 500 * humanize.MiByte
 		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
-		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
 		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
 		if err != nil {
 			return err

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -243,7 +243,6 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 		downloadOpts.SliceSize = 500 * humanize.MiByte
 		// FIXME: make this a config option
 		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
-		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
 		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
 		if err != nil {
 			return err

--- a/pkg/config/optnames.go
+++ b/pkg/config/optnames.go
@@ -6,7 +6,6 @@ const (
 	OptCacheNodesSRVNameByHostCIDR = "cache-nodes-srv-name-by-host-cidr"
 	OptCacheNodesSRVName           = "cache-nodes-srv-name"
 	OptCacheURIPrefixes            = "cache-uri-prefixes"
-	OptCacheUsePathProxy           = "cache-use-path-proxy"
 	OptHostIP                      = "host-ip"
 
 	// Normal options with CLI arguments

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -309,15 +309,6 @@ func (m *ConsistentHashingMode) rewriteRequestToCacheHost(req *http.Request, sta
 	if err != nil {
 		return -1, err
 	}
-	if m.CacheUsePathProxy {
-		// prepend the hostname to the start of the path. The consistent-hash nodes will use this to determine the proxy
-		newPath, err := url.JoinPath(strings.ToLower(req.URL.Host), req.URL.Path)
-		if err != nil {
-			return -1, err
-		}
-		// Ensure wr have a leading slash, things get weird (especially in testing) if we do not.
-		req.URL.Path = fmt.Sprintf("/%s", newPath)
-	}
 	cacheHost := m.CacheHosts[cachePodIndex]
 	logger.Debug().Str("cache_key", fmt.Sprintf("%+v", key)).Int64("start", start).Int64("end", end).Int64("slice_size", m.SliceSize).Int("bucket", cachePodIndex).Msg("consistent hashing")
 	if cacheHost != "" {

--- a/pkg/download/options.go
+++ b/pkg/download/options.go
@@ -25,12 +25,6 @@ type Options struct {
 	// be routed via a pull-through cache
 	CacheableURIPrefixes map[string][]*url.URL
 
-	// CacheUsePathProxy is a flag to indicate whether to use the path proxy mechanism or the host-based mechanism
-	// The default is to use the host-based mechanism, the path proxy mechanism is used when this flag is set to true
-	// and involves prepending the host to the path of the request to the cache. In both cases the Hosts header is
-	// sent to the cache.
-	CacheUsePathProxy bool
-
 	// CacheHosts is a slice of hostnames to use as pull-through caches.
 	// The ordering is significant and will be used with the consistent
 	// hashing algorithm.  The slice may contain empty entries which


### PR DESCRIPTION
This code is highly unreliable and fails in weird ways. This is being removed and will be revisited in an alternate form such as the aliasing concept.