### PR TITLE
Improve consistent-hash testing with httpmock

### DIFF
--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -109,11 +109,13 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 	}
 
 	clientOpts := client.Options{
-		MaxConnPerHost:   viper.GetInt(config.OptMaxConnPerHost),
-		ForceHTTP2:       viper.GetBool(config.OptForceHTTP2),
-		MaxRetries:       viper.GetInt(config.OptRetries),
-		ConnectTimeout:   viper.GetDuration(config.OptConnTimeout),
-		ResolveOverrides: resolveOverrides,
+		MaxRetries: viper.GetInt(config.OptRetries),
+		TransportOpts: client.TransportOptions{
+			ForceHTTP2:       viper.GetBool(config.OptForceHTTP2),
+			ConnectTimeout:   viper.GetDuration(config.OptConnTimeout),
+			MaxConnPerHost:   viper.GetInt(config.OptMaxConnPerHost),
+			ResolveOverrides: resolveOverrides,
+		},
 	}
 	downloadOpts := download.Options{
 		MaxConcurrency: viper.GetInt(config.OptConcurrency),

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -209,11 +209,13 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 		return fmt.Errorf("error parsing resolve overrides: %w", err)
 	}
 	clientOpts := client.Options{
-		ForceHTTP2:       viper.GetBool(config.OptForceHTTP2),
-		MaxRetries:       viper.GetInt(config.OptRetries),
-		ConnectTimeout:   viper.GetDuration(config.OptConnTimeout),
-		MaxConnPerHost:   viper.GetInt(config.OptMaxConnPerHost),
-		ResolveOverrides: resolveOverrides,
+		MaxRetries: viper.GetInt(config.OptRetries),
+		TransportOpts: client.TransportOptions{
+			ForceHTTP2:       viper.GetBool(config.OptForceHTTP2),
+			ConnectTimeout:   viper.GetDuration(config.OptConnTimeout),
+			MaxConnPerHost:   viper.GetInt(config.OptMaxConnPerHost),
+			ResolveOverrides: resolveOverrides,
+		},
 	}
 
 	downloadOpts := download.Options{

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golangci/golangci-lint v1.56.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
+	github.com/jarcoal/httpmock v1.3.1
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/rs/zerolog v1.32.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSo
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jgautheron/goconst v1.7.0 h1:cEqH+YBKLsECnRSd4F4TK5ri8t/aXtt/qoL0Ft252B0=
 github.com/jgautheron/goconst v1.7.0/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjzq7gFzUs=
@@ -394,6 +396,8 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mbilski/exhaustivestruct v1.2.0 h1:wCBmUnSYufAHO6J4AVWY6ff+oxWxsVFrwgOdMUQePUo=
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/mgechev/revive v1.3.7 h1:502QY0vQGe9KtYJ9FpxMz9rL+Fc/P13CI5POL4uHCcE=

--- a/pkg/download/buffer_test.go
+++ b/pkg/download/buffer_test.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 var defaultOpts = download.Options{Client: client.Options{}}
-var http2Opts = download.Options{Client: client.Options{ForceHTTP2: true}}
+var http2Opts = download.Options{Client: client.Options{TransportOpts: client.TransportOptions{ForceHTTP2: true}}}
 
 func benchmarkDownloadURL(opts download.Options, url string, b *testing.B) {
 	bufferMode := download.GetBufferMode(opts)

--- a/pkg/pget_test.go
+++ b/pkg/pget_test.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 var defaultOpts = download.Options{Client: client.Options{}}
-var http2Opts = download.Options{Client: client.Options{ForceHTTP2: true}}
+var http2Opts = download.Options{Client: client.Options{TransportOpts: client.TransportOptions{ForceHTTP2: true}}}
 
 func makeGetter(opts download.Options) *pget.Getter {
 	return &pget.Getter{


### PR DESCRIPTION
Following [a comment by @nickstenning][1], it's his fault.

This changes most (not all) consistent-hash tests to use httpmock to mock out http requests.  This is helpful because standard httptest uses random ports to listen on, which changes URL hash values and messes up the resulting consistent hash behaviour. It's also helpful because I can rewrite some tests that relied on the existence or otherwise of URLs on the public internet.

client.Options has been updated to allow a caller to pass in a Transport; I've also made it clear which options are TransportOptions (and therefore will be ignored if the caller passes their own Transport).

I write a couple of helper functions:

- rangeResponder is an httpmock.Responder that understands http range requests and responds accordingly
- fakeCacheHosts creates an httpmock.MockTransport with a set of pre-registered cache hosts that response to /hello.txt with a static file with contents that are different for each cache host.

[1]: https://github.com/replicate/pget/pull/155#discussion_r1488358253