### PR TITLE
Guarantee Order of Downloads in multifile mode

### DIFF
--- a/cmd/multifile/manifest_test.go
+++ b/cmd/multifile/manifest_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	pget "github.com/replicate/pget/pkg"
-	"github.com/replicate/pget/pkg/client"
 )
 
 // validManifest is a valid manifest file with additional empty lines
@@ -49,58 +49,49 @@ func TestCheckSeenDests(t *testing.T) {
 	}
 
 	// a different destination is fine
-	err := checkSeenDests(seenDests, "/tmp/file2.txt", "https://example.com/file2.txt")
+	err := checkSeenDestinations(seenDests, "/tmp/file2.txt", "https://example.com/file2.txt")
 	assert.NoError(t, err)
 
 	// the same destination with a different URL is not fine
-	err = checkSeenDests(seenDests, "/tmp/file1.txt", "https://example.com/file2.txt")
+	err = checkSeenDestinations(seenDests, "/tmp/file1.txt", "https://example.com/file2.txt")
 	assert.Error(t, err)
 
 	// the same destination with the same URL is also not fine
-	err = checkSeenDests(seenDests, "/tmp/file1.txt", "https://example.com/file1.txt")
+	err = checkSeenDestinations(seenDests, "/tmp/file1.txt", "https://example.com/file1.txt")
 	assert.Error(t, err)
 }
 
 func TestAddEntry(t *testing.T) {
-	entries := make(pget.Manifest)
-	schemeHostExample, _ := client.GetSchemeHostKey("https://example.com")
-	schemHostExample2, _ := client.GetSchemeHostKey("https://example2.com")
+	entries := make(pget.Manifest, 0)
 
-	entries = addEntry(entries, schemeHostExample, "https://example.com/file1.txt", "/tmp/file1.txt")
+	entries, err := entries.AddEntry("https://example.com/file1.txt", "/tmp/file1.txt")
+	require.NoError(t, err)
 	assert.Len(t, entries, 1)
-	assert.Len(t, entries[schemeHostExample], 1)
-	assert.Equal(t, "https://example.com/file1.txt", entries[schemeHostExample][0].URL)
-	assert.Equal(t, "/tmp/file1.txt", entries[schemeHostExample][0].Dest)
-	_, ok := entries[schemeHostExample]
-	assert.True(t, ok)
+	assert.Equal(t, "https://example.com/file1.txt", entries[0].URL())
+	assert.Equal(t, "/tmp/file1.txt", entries[0].Dest)
 
-	entries = addEntry(entries, schemeHostExample, "https://example.com/file2.txt", "/tmp/file2.txt")
-	assert.Len(t, entries, 1)
-	assert.Len(t, entries[schemeHostExample], 2)
-	assert.Equal(t, "https://example.com/file2.txt", entries[schemeHostExample][1].URL)
-	assert.Equal(t, "/tmp/file2.txt", entries[schemeHostExample][1].Dest)
-
-	entries = addEntry(entries, schemHostExample2, "https://example2.com/file3.txt", "/tmp/file3.txt")
+	entries, err = entries.AddEntry("https://example.com/file2.txt", "/tmp/file2.txt")
+	require.NoError(t, err)
 	assert.Len(t, entries, 2)
-	assert.Len(t, entries[schemHostExample2], 1)
-	assert.Equal(t, "https://example2.com/file3.txt", entries[schemHostExample2][0].URL)
-	assert.Equal(t, "/tmp/file3.txt", entries[schemHostExample2][0].Dest)
-	_, ok = entries[schemHostExample2]
-	assert.True(t, ok)
+	assert.Equal(t, "https://example.com/file2.txt", entries[1].URL())
+	assert.Equal(t, "/tmp/file2.txt", entries[1].Dest)
+
+	entries, err = entries.AddEntry("https://example2.com/file3.txt", "/tmp/file3.txt")
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+	assert.Equal(t, "https://example2.com/file3.txt", entries[2].URL())
+	assert.Equal(t, "/tmp/file3.txt", entries[2].Dest)
 
 }
 
 func TestParseManifest(t *testing.T) {
-	manifest := strings.Split(validManifest[1:], "\n")
-	manifestMap, err := parseManifest(strings.NewReader(validManifest))
-	hostSchemeKey, _ := client.GetSchemeHostKey(manifest[0])
+	parsedManifest, err := parseManifest(strings.NewReader(validManifest))
 	assert.NoError(t, err)
-	assert.Len(t, manifestMap, 1)
-	assert.Len(t, manifestMap[hostSchemeKey], 3)
+	assert.Len(t, parsedManifest, 3)
 
-	manifestMap, err = parseManifest(strings.NewReader(invalidManifest))
+	parsedManifest, err = parseManifest(strings.NewReader(invalidManifest))
 	assert.Error(t, err)
-	assert.Len(t, manifestMap, 0)
+	assert.Len(t, parsedManifest, 0)
 }
 
 func TestManifestFile(t *testing.T) {

--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -160,16 +160,11 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 	throughput := float64(totalFileSize) / elapsedTime.Seconds()
 	logger := logging.GetLogger()
 	logger.Info().
-		Int("file_count", numEntries(manifest)).
+		Int("file_count", len(manifest)).
 		Str("total_bytes_downloaded", humanize.Bytes(uint64(totalFileSize))).
 		Str("throughput", fmt.Sprintf("%s/s", humanize.Bytes(uint64(throughput)))).
 		Str("elapsed_time", fmt.Sprintf("%.3fs", elapsedTime.Seconds())).
 		Msg("Metrics")
 
 	return nil
-}
-
-func numEntries(manifest pget.Manifest) int {
-	return len(manifest)
-
 }

--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -169,9 +169,7 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 	return nil
 }
 
-func numEntries(manifest pget.Manifest) (totalEntries int) {
-	for _, entries := range manifest {
-		totalEntries += len(entries)
-	}
-	return
+func numEntries(manifest pget.Manifest) int {
+	return len(manifest)
+
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -216,16 +215,4 @@ func (d *transportDialer) DialContext(ctx context.Context, network, addr string)
 		addr = addrOverride
 	}
 	return d.Dialer.DialContext(ctx, network, addr)
-}
-
-func GetSchemeHostKey(urlString string) (string, error) {
-	parsedURL, err := url.Parse(urlString)
-	if err != nil {
-		return "", err
-	}
-	return getSchemeHostKey(parsedURL), err
-}
-
-func getSchemeHostKey(url *url.URL) string {
-	return fmt.Sprintf("%s://%s", url.Scheme, url.Host)
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -14,14 +14,6 @@ import (
 	"github.com/replicate/pget/pkg/config"
 )
 
-func TestGetSchemeHostKey(t *testing.T) {
-	expected := "http://example.com"
-	actual, err := client.GetSchemeHostKey("http://example.com/foo/bar;baz/quux?animal=giraffe")
-
-	assert.NoError(t, err)
-	assert.Equal(t, expected, actual)
-}
-
 func TestRetryPolicy(t *testing.T) {
 	bgCtx := context.Background()
 	chCtx := context.WithValue(bgCtx, config.ConsistentHashingStrategyKey, true)

--- a/pkg/pget_test.go
+++ b/pkg/pget_test.go
@@ -161,7 +161,7 @@ func testDownloadMultipleFiles(opts download.Options, sizes []int64, t *testing.
 	manifest := make(pget.Manifest, 0)
 
 	for _, srcFilename := range srcFilenames {
-		manifest, err = manifest.AddEntry(ts.URL+"/"+srcFilename, filepath.Join(outputDir, srcFilename))
+		manifest = manifest.AddEntry(ts.URL+"/"+srcFilename, filepath.Join(outputDir, srcFilename))
 		require.NoError(t, err)
 	}
 
@@ -195,4 +195,19 @@ func TestDownloadFive10MFiles(t *testing.T) {
 		10 * humanize.MiByte,
 		10 * humanize.MiByte,
 	}, t)
+}
+
+func TestManifest_AddEntry(t *testing.T) {
+	entries := make(pget.Manifest, 0)
+
+	entries = entries.AddEntry("https://example.com/file1.txt", "/tmp/file1.txt")
+	assert.Len(t, entries, 1)
+	entries = entries.AddEntry("https://example.org/file2.txt", "/tmp/file2.txt")
+	assert.Len(t, entries, 2)
+
+	assert.Equal(t, "https://example.com/file1.txt", entries[0].URL)
+	assert.Equal(t, "/tmp/file1.txt", entries[0].Dest)
+	assert.Equal(t, "https://example.org/file2.txt", entries[1].URL)
+	assert.Equal(t, "/tmp/file2.txt", entries[1].Dest)
+
 }

--- a/pkg/pget_test.go
+++ b/pkg/pget_test.go
@@ -158,19 +158,14 @@ func testDownloadMultipleFiles(opts download.Options, sizes []int64, t *testing.
 	ts := httptest.NewServer(http.FileServer(http.Dir(inputDir)))
 	defer ts.Close()
 
-	entries := make([]pget.ManifestEntry, len(sizes))
-	for i, srcFilename := range srcFilenames {
-		entries[i] = pget.ManifestEntry{
-			URL:  ts.URL + "/" + srcFilename,
-			Dest: outputDir + "/" + srcFilename,
-		}
+	manifest := make(pget.Manifest, 0)
+
+	for _, srcFilename := range srcFilenames {
+		manifest, err = manifest.AddEntry(ts.URL+"/"+srcFilename, filepath.Join(outputDir, srcFilename))
+		require.NoError(t, err)
 	}
 
 	getter := makeGetter(opts)
-
-	manifest := pget.Manifest{
-		"ignored-value": entries,
-	}
 
 	actualTotalSize, _, err := getter.DownloadFiles(context.Background(), manifest)
 	assert.NoError(t, err)


### PR DESCRIPTION
Refactor the manifest to ensure that the order is guaranteed when downloading via multifile. Some future consumers will require guaranteed ordering. This also reduces complexity as the schemeHost is no longer needed.