### PR TITLE
Reuse buffers used by bufferedReader

### DIFF
--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -60,6 +60,7 @@ func GetConsistentHashingMode(opts Options) (*ConsistentHashingMode, error) {
 		queue:            queue,
 	}
 	m.pool = newBufferPool(m.chunkSize())
+	fallbackStrategy.pool = m.pool
 	return m, nil
 }
 

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -27,6 +27,7 @@ type ConsistentHashingMode struct {
 	// we use this errgroup as a semaphore (via sem.SetLimit())
 	sem   *errgroup.Group
 	queue *workQueue
+	pool  *bufferPool
 }
 
 type CacheKey struct {
@@ -51,13 +52,15 @@ func GetConsistentHashingMode(opts Options) (*ConsistentHashingMode, error) {
 		queue:   queue,
 	}
 
-	return &ConsistentHashingMode{
+	m := &ConsistentHashingMode{
 		Client:           client,
 		Options:          opts,
 		FallbackStrategy: fallbackStrategy,
 		sem:              sem,
 		queue:            queue,
-	}, nil
+	}
+	m.pool = newBufferPool(m.chunkSize())
+	return m, nil
 }
 
 func (m *ConsistentHashingMode) chunkSize() int64 {
@@ -104,7 +107,7 @@ func (m *ConsistentHashingMode) Fetch(ctx context.Context, urlString string) (io
 		return m.FallbackStrategy.Fetch(ctx, urlString)
 	}
 
-	br := newBufferedReader(m.chunkSize())
+	br := newBufferedReader(m.pool)
 	firstReqResultCh := make(chan firstReqResult)
 	m.queue.submit(func() {
 		m.sem.Go(func() error {
@@ -193,7 +196,7 @@ func (m *ConsistentHashingMode) Fetch(ctx context.Context, urlString string) (io
 					chunkEnd = sliceEnd
 				}
 
-				br := newBufferedReader(m.chunkSize())
+				br := newBufferedReader(m.pool)
 				readersCh <- br
 				m.sem.Go(func() error {
 					defer br.done()


### PR DESCRIPTION
This is an alternative to #174.  The key differences are:

- we use sync.Pool to store *bytes.Buffer instances rather than bufferedReader instances
- we keep the ready channel instead of using sync.Cond
- we return the buffer to the pool in Read() rather than requiring an explicit Close()

Overall this changes fewer parts of the codebase and is (IMHO) simpler and easier to understand.