### PR TITLE
Check Tar Extract enablement in PersistentPreRunE

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -145,6 +145,12 @@ func rootPersistentPreRunEFunc(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if viper.GetBool(config.OptExtract) {
+		// TODO: decide what to do when --output is set *and* --extract is set
+		log.Debug().Msg("Tar Extract Enabled")
+		viper.Set(config.OptOutputConsumer, config.ConsumerTarExtractor)
+	}
+
 	return nil
 }
 
@@ -263,12 +269,6 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 	getter := pget.Getter{
 		Downloader: download.GetBufferMode(downloadOpts),
 		Consumer:   consumer,
-	}
-
-	if viper.GetBool(config.OptExtract) {
-		// TODO: decide what to do when --output is set *and* --extract is set
-		log.Debug().Msg("Tar Extract Enabled")
-		viper.Set(config.OptOutputConsumer, config.ConsumerTarExtractor)
 	}
 
 	// TODO DRY this

--- a/pkg/extract/tar.go
+++ b/pkg/extract/tar.go
@@ -54,6 +54,10 @@ func TarFile(reader io.Reader, destDir string, overwrite bool) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
+			logger.Debug().
+				Str("target", target).
+				Str("perms", fmt.Sprintf("%o", header.Mode)).
+				Msg("Tar: Directory")
 			if err := os.MkdirAll(target, cleanFileMode(os.FileMode(header.Mode))); err != nil {
 				return err
 			}
@@ -62,6 +66,10 @@ func TarFile(reader io.Reader, destDir string, overwrite bool) error {
 			if overwrite {
 				openFlags |= os.O_TRUNC
 			}
+			logger.Debug().
+				Str("target", target).
+				Str("perms", fmt.Sprintf("%o", header.Mode)).
+				Msg("Tar: File")
 			targetFile, err := os.OpenFile(target, openFlags, cleanFileMode(os.FileMode(header.Mode)))
 			if err != nil {
 				return err
@@ -75,6 +83,10 @@ func TarFile(reader io.Reader, destDir string, overwrite bool) error {
 			}
 		case tar.TypeSymlink, tar.TypeLink:
 			// Defer creation of
+			logger.Debug().Str("link_type", string(header.Typeflag)).
+				Str("old_name", header.Linkname).
+				Str("new_name", target).
+				Msg("Tar: (Defer) Link")
 			links = append(links, &link{linkType: header.Typeflag, oldName: header.Linkname, newName: target})
 		default:
 			return fmt.Errorf("unsupported file type for %s, typeflag %s", header.Name, string(header.Typeflag))
@@ -95,6 +107,7 @@ func TarFile(reader io.Reader, destDir string, overwrite bool) error {
 }
 
 func createLinks(links []*link, destDir string, overwrite bool) error {
+	logger := logging.GetLogger()
 	for _, link := range links {
 		targetDir := filepath.Dir(link.newName)
 		if err := os.MkdirAll(targetDir, 0755); err != nil {
@@ -103,10 +116,18 @@ func createLinks(links []*link, destDir string, overwrite bool) error {
 		switch link.linkType {
 		case tar.TypeLink:
 			oldPath := filepath.Join(destDir, link.oldName)
+			logger.Debug().
+				Str("old_path", oldPath).
+				Str("new_path", link.newName).
+				Msg("Tar: creating hard link")
 			if err := createHardLink(oldPath, link.newName, overwrite); err != nil {
 				return fmt.Errorf("error creating hard link from %s to %s: %w", oldPath, link.newName, err)
 			}
 		case tar.TypeSymlink:
+			logger.Debug().
+				Str("old_path", link.oldName).
+				Str("new_path", link.newName).
+				Msg("Tar: creating symlink")
 			if err := createSymlink(link.oldName, link.newName, overwrite); err != nil {
 				return fmt.Errorf("error creating symlink from %s to %s: %w", link.oldName, link.newName, err)
 			}


### PR DESCRIPTION
Check for the tar extract flag being set in PersistentPreRunE, this ensures that there is no out-of-order operation concerns such as setting the extractor *after* we already get and create the consumer.