### PR TITLE
Improve pidfile location for non-root

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -85,7 +85,9 @@ func defaultPidFilePath() string {
 	// If we're on OS X, use the user's home directory
 	// Otherwise, use /run
 	path := "/run/pget.pid"
-	if runtime.GOOS == "darwin" {
+	if xdgPath, ok := os.LookupEnv("XDG_RUNTIME_DIR"); ok {
+		path = xdgPath + "/pget.pid"
+	} else if runtime.GOOS == "darwin" {
 		path = os.Getenv("HOME") + "/.pget.pid"
 	}
 	return path


### PR DESCRIPTION
Improve pidfile location for non-root users. Use XDG_RUNTIME_PATH if set.

Closes: #128 