### PR TITLE
Create path when using file writer

### DIFF
--- a/pkg/consumer/write_file.go
+++ b/pkg/consumer/write_file.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 type FileWriter struct {
@@ -14,6 +15,10 @@ var _ Consumer = &FileWriter{}
 
 func (f *FileWriter) Consume(reader io.Reader, destPath string) error {
 	openFlags := os.O_WRONLY | os.O_CREATE
+	targetDir := filepath.Dir(destPath)
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("error creating directory: %w", err)
+	}
 	if f.Overwrite {
 		openFlags |= os.O_TRUNC
 	}


### PR DESCRIPTION
For a better user expeirence create the filepath for the output file. This is especially relevant in multifile mode so that a user does not need to create all the directories prior to running pget.