### PR TITLE
Revert "implement Wait() on Strategy to fetch remaining errors (#179)"

### DIFF
--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -73,6 +73,7 @@ func (m *BufferMode) Fetch(ctx context.Context, url string) (io.Reader, int64, e
 			defer br.Done()
 			firstChunkResp, err := m.DoRequest(ctx, 0, m.chunkSize()-1, url)
 			if err != nil {
+				br.err = err
 				firstReqResultCh <- firstReqResult{err: err}
 				return err
 			}
@@ -151,6 +152,7 @@ func (m *BufferMode) Fetch(ctx context.Context, url string) (io.Reader, int64, e
 				defer br.Done()
 				resp, err := m.DoRequest(ctx, start, end, trueURL)
 				if err != nil {
+					br.err = err
 					return err
 				}
 				defer resp.Body.Close()
@@ -168,10 +170,6 @@ func (m *BufferMode) Fetch(ctx context.Context, url string) (io.Reader, int64, e
 	})
 
 	return newChanMultiReader(readersCh), fileSize, nil
-}
-
-func (m *BufferMode) Wait() error {
-	return m.sem.Wait()
 }
 
 func (m *BufferMode) DoRequest(ctx context.Context, start, end int64, trueURL string) (*http.Response, error) {

--- a/pkg/download/buffered_reader.go
+++ b/pkg/download/buffered_reader.go
@@ -20,6 +20,7 @@ type bufferedReader struct {
 	// ready channel is closed when we're ready to read
 	ready chan struct{}
 	buf   *bufio.Reader
+	err   error
 	pool  *bufferPool
 }
 
@@ -41,6 +42,9 @@ func (b *bufferedReader) Read(buf []byte) (int, error) {
 	<-b.ready
 	if b.buf == nil {
 		return 0, io.EOF
+	}
+	if b.err != nil {
+		return 0, b.err
 	}
 	n, err := b.buf.Read(buf)
 	// If we've read all the data,

--- a/pkg/download/consistent_hashing_test.go
+++ b/pkg/download/consistent_hashing_test.go
@@ -270,8 +270,6 @@ func TestConsistentHashing(t *testing.T) {
 			require.NoError(t, err)
 			bytes, err := io.ReadAll(reader)
 			require.NoError(t, err)
-			err = strategy.Wait()
-			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedOutput, string(bytes))
 		})
@@ -323,8 +321,6 @@ func TestConsistentHashingPathBased(t *testing.T) {
 			require.NoError(t, err)
 			bytes, err := io.ReadAll(reader)
 			require.NoError(t, err)
-			err = strategy.Wait()
-			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedOutput, string(bytes))
 		})
@@ -355,8 +351,6 @@ func TestConsistentHashRetries(t *testing.T) {
 	reader, _, err := strategy.Fetch(ctx, "http://fake.replicate.delivery/hello.txt")
 	require.NoError(t, err)
 	bytes, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	err = strategy.Wait()
 	require.NoError(t, err)
 
 	// with a functional hostnames[0], we'd see 0344760706165500, but instead we
@@ -393,8 +387,6 @@ func TestConsistentHashRetriesMissingHostname(t *testing.T) {
 	require.NoError(t, err)
 	bytes, err := io.ReadAll(reader)
 	require.NoError(t, err)
-	err = strategy.Wait()
-	require.NoError(t, err)
 
 	// with a functional hostnames[0], we'd see 0344760706165500, but instead we
 	// should fall back to this. Note that each 0 value has been changed to a
@@ -429,8 +421,6 @@ func TestConsistentHashRetriesTwoHosts(t *testing.T) {
 	require.NoError(t, err)
 	bytes, err := io.ReadAll(reader)
 	require.NoError(t, err)
-	err = strategy.Wait()
-	require.NoError(t, err)
 
 	assert.Equal(t, "0000000000000000", string(bytes))
 }
@@ -458,8 +448,6 @@ func TestConsistentHashingHasFallback(t *testing.T) {
 	require.NoError(t, err)
 	bytes, err := io.ReadAll(reader)
 	require.NoError(t, err)
-	err = strategy.Wait()
-	require.NoError(t, err)
 
 	assert.Equal(t, "0000000000000000", string(bytes))
 }
@@ -486,10 +474,6 @@ type testStrategy struct {
 func (s *testStrategy) Fetch(ctx context.Context, url string) (io.Reader, int64, error) {
 	s.fetchCalledCount++
 	return io.NopCloser(strings.NewReader("00")), -1, nil
-}
-
-func (s *testStrategy) Wait() error {
-	return nil
 }
 
 func (s *testStrategy) DoRequest(ctx context.Context, start, end int64, url string) (*http.Response, error) {

--- a/pkg/download/strategy.go
+++ b/pkg/download/strategy.go
@@ -15,9 +15,6 @@ type Strategy interface {
 	// This is the primary method that should be called to initiate a download of a file.
 	Fetch(ctx context.Context, url string) (result io.Reader, fileSize int64, err error)
 
-	// Wait waits until all requests have completed, and returns the first error encountered, if any.
-	Wait() error
-
 	// DoRequest sends an HTTP GET request with a specified range of bytes to the given URL using the provided context.
 	// It returns the HTTP response and any error encountered during the request. It is intended that Fetch calls DoRequest
 	// and that each chunk is downloaded with a call to DoRequest. DoRequest is exposed so that consistent-hashing can

--- a/pkg/pget.go
+++ b/pkg/pget.go
@@ -53,11 +53,6 @@ func (g *Getter) DownloadFile(ctx context.Context, url string, dest string) (int
 	if err != nil {
 		return fileSize, 0, fmt.Errorf("error writing file: %w", err)
 	}
-	err = g.Downloader.Wait()
-	if err != nil {
-		return fileSize, 0, err
-	}
-
 	// writeElapsed := time.Since(writeStartTime)
 	totalElapsed := time.Since(downloadStartTime)
 


### PR DESCRIPTION
This reverts commit c72c38485b2389513b8051912b47e7f63db54641.

We cannot add more to the underlying waitgroup in eg after we call .Wait(). We're calling .Wait() as part of DownloadFile which could in some cases result in after .Wait() before return additional additions to the waitgroup. This is surfaced in multifile mode when the multifile number of buffers is below a critical threshold allowing for the downloader to begin a second file before the first file completed.

Closes: #188