### PR TITLE
Add STDOut Consumer

### DIFF
--- a/cmd/multifile/manifest.go
+++ b/cmd/multifile/manifest.go
@@ -90,7 +90,7 @@ func parseManifest(file io.Reader) (pget.Manifest, error) {
 		// and make the consumer responsible for knowing if this
 		// is allowed/not allowed/etc
 		consumer := viper.GetString(config.OptOutputConsumer)
-		if consumer != config.ConsumerNull {
+		if consumer != config.ConsumerNull && consumer != config.ConsumerSTDOUT {
 			err = checkSeenDestinations(seenDestinations, dest, url)
 			if err != nil {
 				if errors.Is(err, errDupeURLDestCombo) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ const (
 	ConsumerFile         = "file"
 	ConsumerTarExtractor = "tar-extractor"
 	ConsumerNull         = "null"
+	ConsumerSTDOUT       = "stdout"
 )
 
 var (
@@ -153,6 +154,8 @@ func GetConsumer() (consumer.Consumer, error) {
 		return &consumer.TarExtractor{Overwrite: enableOverwrite}, nil
 	case ConsumerNull:
 		return &consumer.NullWriter{}, nil
+	case ConsumerSTDOUT:
+		return &consumer.StdoutConsumer{}, nil
 	default:
 		return nil, fmt.Errorf("invalid consumer specified: %s", consumerName)
 	}

--- a/pkg/consumer/stdout.go
+++ b/pkg/consumer/stdout.go
@@ -1,0 +1,20 @@
+package consumer
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var _ Consumer = &StdoutConsumer{}
+
+type StdoutConsumer struct {
+}
+
+func (s StdoutConsumer) Consume(reader io.Reader, destPath string) error {
+	_, err := io.Copy(os.Stdout, reader)
+	if err != nil {
+		return fmt.Errorf("error writing to stdout: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Add an STDOut consumer for usecases where streaming the bytes to another process is appropriate. If the consumer is STDOUT we are restricted to a single file download concurrently in multifile mode.