### PR TITLE
use snapshot.version_template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incminor .Version }}-devbuild"
+  version_template: "{{ incminor .Version }}-devbuild"
 universal_binaries:
   - replace: false
 changelog:


### PR DESCRIPTION
Do not use snapshot.name_template in the .goreleaser.yaml use snapshot.version_template (non-deprecated)