### PR TITLE
Support override table in pget

### DIFF
--- a/pkg/config/optnames.go
+++ b/pkg/config/optnames.go
@@ -22,6 +22,7 @@ const (
 	OptMaxConcurrentFiles = "max-concurrent-files"
 	OptMinimumChunkSize   = "minimum-chunk-size"
 	OptOutputConsumer     = "output"
+	OptOverridesFile      = "overrides-file"
 	OptPIDFile            = "pid-file"
 	OptResolve            = "resolve"
 	OptRetries            = "retries"

--- a/pkg/overrides/routing_table.go
+++ b/pkg/overrides/routing_table.go
@@ -1,0 +1,31 @@
+package overrides
+
+import (
+	"encoding/json"
+	"os"
+)
+
+type RoutingTable map[string]string
+
+type RoutingTableRecord struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func ParseRoutingTable(filepath string) (RoutingTable, error) {
+	r := make([]RoutingTableRecord, 0)
+	table := make(RoutingTable)
+	f, err := os.Open(filepath)
+	if err != nil {
+		return table, err
+	}
+	defer f.Close()
+	err = json.NewDecoder(f).Decode(&r)
+	if err != nil {
+		return table, err
+	}
+	for _, record := range r {
+		table[record.Key] = record.Value
+	}
+	return table, nil
+}

--- a/pkg/pget.go
+++ b/pkg/pget.go
@@ -12,6 +12,7 @@ import (
 	"github.com/replicate/pget/pkg/consumer"
 	"github.com/replicate/pget/pkg/download"
 	"github.com/replicate/pget/pkg/logging"
+	"github.com/replicate/pget/pkg/overrides"
 )
 
 type Getter struct {
@@ -22,6 +23,7 @@ type Getter struct {
 
 type Options struct {
 	MaxConcurrentFiles int
+	RoutingTable       overrides.RoutingTable
 }
 
 type ManifestEntry struct {
@@ -42,6 +44,9 @@ func (g *Getter) DownloadFile(ctx context.Context, url string, dest string) (int
 	}
 	logger := logging.GetLogger()
 	downloadStartTime := time.Now()
+	if override, ok := g.Options.RoutingTable[url]; ok {
+		url = override
+	}
 	buffer, fileSize, err := g.Downloader.Fetch(ctx, url)
 	if err != nil {
 		return fileSize, 0, err


### PR DESCRIPTION
### Summary

Add option to follow override routing table defined in a JSON file like

```
[
  {
    "key": <route>,
    "value": <override route>
  },
  ...
]
```