### PR TITLE
Imeplement Cache Support in BufferMode

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.3
+golang 1.24.1

--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -132,10 +132,9 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 		return fmt.Errorf("error getting consumer: %w", err)
 	}
 
-	getter := &pget.Getter{
-		Downloader: download.GetBufferMode(downloadOpts),
-		Consumer:   consumer,
-		Options:    pgetOpts,
+	getter := pget.Getter{
+		Consumer: consumer,
+		Options:  pgetOpts,
 	}
 
 	// TODO DRY this
@@ -154,6 +153,10 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 		downloadOpts.CacheHosts = []string{cacheHostname}
 		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
 		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
+	}
+
+	if getter.Downloader == nil {
+		getter.Downloader = download.GetBufferMode(downloadOpts)
 	}
 
 	totalFileSize, elapsedTime, err := getter.DownloadFiles(ctx, manifest)

--- a/cmd/multifile/multifile.go
+++ b/cmd/multifile/multifile.go
@@ -143,14 +143,17 @@ func multifileExecute(ctx context.Context, manifest pget.Manifest) error {
 		downloadOpts.SliceSize = 500 * humanize.MiByte
 		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
 		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
-		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
-		if err != nil {
+		if downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName); err != nil {
 			return err
 		}
 		getter.Downloader, err = download.GetConsistentHashingMode(downloadOpts)
 		if err != nil {
 			return err
 		}
+	} else if cacheHostname := config.CacheServiceHostname(); cacheHostname != "" {
+		downloadOpts.CacheHosts = []string{cacheHostname}
+		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
+		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
 	}
 
 	totalFileSize, elapsedTime, err := getter.DownloadFiles(ctx, manifest)

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -273,9 +273,8 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 	}
 
 	getter := pget.Getter{
-		Downloader: download.GetBufferMode(downloadOpts),
-		Consumer:   consumer,
-		Options:    pgetOpts,
+		Consumer: consumer,
+		Options:  pgetOpts,
 	}
 
 	// TODO DRY this
@@ -294,6 +293,10 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 		downloadOpts.CacheHosts = []string{cacheHostname}
 		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
 		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
+	}
+
+	if getter.Downloader == nil {
+		getter.Downloader = download.GetBufferMode(downloadOpts)
 	}
 
 	_, _, err = getter.DownloadFile(ctx, urlString, dest)

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -281,17 +281,19 @@ func rootExecute(ctx context.Context, urlString, dest string) error {
 	// TODO DRY this
 	if srvName := config.GetCacheSRV(); srvName != "" {
 		downloadOpts.SliceSize = 500 * humanize.MiByte
-		// FIXME: make this a config option
 		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
 		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
-		downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName)
-		if err != nil {
+		if downloadOpts.CacheHosts, err = cli.LookupCacheHosts(srvName); err != nil {
 			return err
 		}
 		getter.Downloader, err = download.GetConsistentHashingMode(downloadOpts)
 		if err != nil {
 			return err
 		}
+	} else if cacheHostname := config.CacheServiceHostname(); cacheHostname != "" {
+		downloadOpts.CacheHosts = []string{cacheHostname}
+		downloadOpts.CacheableURIPrefixes = config.CacheableURIPrefixes()
+		downloadOpts.CacheUsePathProxy = viper.GetBool(config.OptCacheUsePathProxy)
 	}
 
 	_, _, err = getter.DownloadFile(ctx, urlString, dest)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/replicate/pget
 
-go 1.23
+go 1.24
 
-toolchain go1.23.3
+toolchain go1.24.1
 
 require (
 	github.com/dgryski/go-jump v0.0.0-20211018200510-ba001c3ffce0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -207,3 +207,23 @@ func CacheableURIPrefixes() map[string][]*url.URL {
 	}
 	return result
 }
+
+func CacheServiceHostname() string {
+	logger := logging.GetLogger()
+	target := viper.GetString(OptCacheServiceHostname)
+	parsed, err := url.Parse(target)
+	if err != nil {
+		logger.Error().
+			Err(err).
+			Str("target", target).
+			Bool("enabled", false).
+			Msg("Cache Service")
+		return ""
+	}
+	logger.Info().
+		Str("target", parsed.Host).
+		Str("scheme", parsed.Scheme).
+		Bool("enabled", true).
+		Msg("Cache Service")
+	return target
+}

--- a/pkg/config/optnames.go
+++ b/pkg/config/optnames.go
@@ -5,6 +5,7 @@ const (
 	// envvar, not command line
 	OptCacheNodesSRVNameByHostCIDR = "cache-nodes-srv-name-by-host-cidr"
 	OptCacheNodesSRVName           = "cache-nodes-srv-name"
+	OptCacheServiceHostname        = "cache-service-hostname"
 	OptCacheURIPrefixes            = "cache-uri-prefixes"
 	OptCacheUsePathProxy           = "cache-use-path-proxy"
 	OptHostIP                      = "host-ip"

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -37,8 +37,13 @@ func GetConsistentHashingMode(opts Options) (*ConsistentHashingMode, error) {
 	client := client.NewHTTPClient(opts.Client)
 
 	fallbackStrategy := &BufferMode{
-		Client:  client,
-		Options: opts,
+		Client: client,
+		// Do not pass cache-related options to the fallback strategy
+		Options: Options{
+			Client:         opts.Client,
+			ChunkSize:      opts.ChunkSize,
+			MaxConcurrency: opts.MaxConcurrency,
+		},
 	}
 
 	m := &ConsistentHashingMode{


### PR DESCRIPTION
Support specifying a cache endpoint for pget to utilize. This is
distinct from the CH mode as we do not need SRV records, a static target
is sufficient.

Using the standard PROXY env variables will result in non-pget traffic
being redirected. The Cache should be explicitly opt-in.