### PR TITLE
Fix off by 1 error

### DIFF
--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -56,6 +56,7 @@ func (m *BufferMode) getFileSizeFromContentLength(contentLength string) (int64, 
 	if err != nil {
 		return 0, err
 	}
+
 	return size, nil
 }
 

--- a/pkg/download/buffer.go
+++ b/pkg/download/buffer.go
@@ -56,9 +56,7 @@ func (m *BufferMode) getFileSizeFromContentLength(contentLength string) (int64, 
 	if err != nil {
 		return 0, err
 	}
-	// Because content-length is a length, it will be 1-indexed. However, we expect a 0
-	// indexed value here, so we subtract 1 from the content length
-	return size - 1, nil
+	return size, nil
 }
 
 func (m *BufferMode) getFileSizeFromContentRange(contentRange string) (int64, error) {

--- a/pkg/download/consistent_hashing.go
+++ b/pkg/download/consistent_hashing.go
@@ -85,9 +85,8 @@ func (m *ConsistentHashingMode) getFileSizeFromContentLength(contentLength strin
 	if err != nil {
 		return 0, err
 	}
-	// Because content-length is a length, it will be 1-indexed. However, we expect a 0
-	// indexed value here, so we subtract 1 from the content length
-	return size - 1, nil
+
+	return size, nil
 }
 
 func (m *ConsistentHashingMode) getFileSizeFromContentRange(contentRange string) (int64, error) {

--- a/pkg/pget_test.go
+++ b/pkg/pget_test.go
@@ -133,6 +133,24 @@ func testDownloadSingleFile(opts download.Options, size int64, t *testing.T) {
 	assert.NoError(t, err, "source file and dest file should be identical")
 }
 
+func TestDownloadSmallFileWith200(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{\"message\": \"Tweet! Tweet!\"}"))
+	}))
+	defer ts.Close()
+
+	dest := tempFilename()
+	defer os.Remove(dest)
+
+	getter := makeGetter(defaultOpts)
+
+	_, _, err := getter.DownloadFile(context.Background(), ts.URL+"/hello.txt", dest)
+	assert.NoError(t, err)
+
+	assertFileHasContent(t, []byte("{\"message\": \"Tweet! Tweet!\"}"), dest)
+}
+
 func TestDownload10MH1(t *testing.T)  { testDownloadSingleFile(defaultOpts, 10*humanize.MiByte, t) }
 func TestDownload100MH1(t *testing.T) { testDownloadSingleFile(defaultOpts, 100*humanize.MiByte, t) }
 func TestDownload10MH2(t *testing.T)  { testDownloadSingleFile(http2Opts, 10*humanize.MiByte, t) }

--- a/pkg/pget_test.go
+++ b/pkg/pget_test.go
@@ -136,7 +136,8 @@ func testDownloadSingleFile(opts download.Options, size int64, t *testing.T) {
 func TestDownloadSmallFileWith200(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("{\"message\": \"Tweet! Tweet!\"}"))
+		_, err := w.Write([]byte("{\"message\": \"Tweet! Tweet!\"}"))
+		assert.NoError(t, err)
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
### Summary

Due to a misunderstanding in regex, I thought the value here would be a 0 indexed value. However, it is a 1 indexed value, so there was no need to do the subtraction by 1 that I put in here. This caused an off by 1 error when trying to write the file.

### Test Plan

Added a unit test for this. If you try to run this unit test with the old version of this code, you should see the error
```
--- FAIL: TestDownloadSmallFileWith200 (0.01s)
    /pget/pkg/pget_test.go:149: 
        	Error Trace:	/pget/pkg/pget_test.go:149
        	Error:      	Received unexpected error:
        	            	error writing file: expected 27 bytes, wrote 28
        	Test:       	TestDownloadSmallFileWith200
```