### PR TITLE
Revert auth header changes

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -165,7 +165,6 @@ func rootPersistentPostRunEFunc(cmd *cobra.Command, args []string) error {
 
 func persistentFlags(cmd *cobra.Command) error {
 	// Persistent Flags (applies to all commands/subcommands)
-	cmd.PersistentFlags().String(config.OptAuthToken, "", "Auth token")
 	cmd.PersistentFlags().IntVarP(&concurrency, config.OptConcurrency, "c", runtime.GOMAXPROCS(0)*4, "Maximum number of concurrent downloads/maximum number of chunks for a given file")
 	cmd.PersistentFlags().IntVar(&concurrency, config.OptMaxChunks, runtime.GOMAXPROCS(0)*4, "Maximum number of chunks for a given file")
 	cmd.PersistentFlags().Duration(config.OptConnTimeout, 5*time.Second, "Timeout for establishing a connection, format is <number><unit>, e.g. 10s")

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -165,7 +165,7 @@ func rootPersistentPostRunEFunc(cmd *cobra.Command, args []string) error {
 
 func persistentFlags(cmd *cobra.Command) error {
 	// Persistent Flags (applies to all commands/subcommands)
-	cmd.PersistentFlags().String(config.OptAuthHeader, "", "Authorization header")
+	cmd.PersistentFlags().String(config.OptAuthToken, "", "Auth token")
 	cmd.PersistentFlags().IntVarP(&concurrency, config.OptConcurrency, "c", runtime.GOMAXPROCS(0)*4, "Maximum number of concurrent downloads/maximum number of chunks for a given file")
 	cmd.PersistentFlags().IntVar(&concurrency, config.OptMaxChunks, runtime.GOMAXPROCS(0)*4, "Maximum number of chunks for a given file")
 	cmd.PersistentFlags().Duration(config.OptConnTimeout, 5*time.Second, "Timeout for establishing a connection, format is <number><unit>, e.g. 10s")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -35,13 +35,13 @@ type HTTPClient interface {
 // utilizing a client pool. If the OptMaxConnPerHost option is not set, the client pool will not be used.
 type PGetHTTPClient struct {
 	*http.Client
-	authHeader string
+	authToken string
 }
 
 func (c *PGetHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", fmt.Sprintf("pget/%s", version.GetVersion()))
-	if c.authHeader != "" {
-		req.Header.Set("Authorization", c.authHeader)
+	if c.authToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
 	}
 	return c.Client.Do(req)
 }
@@ -104,7 +104,7 @@ func NewHTTPClient(opts Options) HTTPClient {
 	}
 
 	client := retryClient.StandardClient()
-	return &PGetHTTPClient{Client: client, authHeader: viper.GetString(config.OptAuthHeader)}
+	return &PGetHTTPClient{Client: client, authToken: viper.GetString(config.OptAuthToken)}
 }
 
 // RetryPolicy wraps retryablehttp.DefaultRetryPolicy and included additional logic:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/replicate/pget/pkg/config"
@@ -35,14 +33,10 @@ type HTTPClient interface {
 // utilizing a client pool. If the OptMaxConnPerHost option is not set, the client pool will not be used.
 type PGetHTTPClient struct {
 	*http.Client
-	authToken string
 }
 
 func (c *PGetHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", fmt.Sprintf("pget/%s", version.GetVersion()))
-	if c.authToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
-	}
 	return c.Client.Do(req)
 }
 
@@ -104,7 +98,7 @@ func NewHTTPClient(opts Options) HTTPClient {
 	}
 
 	client := retryClient.StandardClient()
-	return &PGetHTTPClient{Client: client, authToken: viper.GetString(config.OptAuthToken)}
+	return &PGetHTTPClient{Client: client}
 }
 
 // RetryPolicy wraps retryablehttp.DefaultRetryPolicy and included additional logic:

--- a/pkg/config/optnames.go
+++ b/pkg/config/optnames.go
@@ -12,7 +12,6 @@ const (
 	OptMetricsEndpoint             = "metrics-endpoint"
 
 	// Normal options with CLI arguments
-	OptAuthToken          = "auth-token"
 	OptConcurrency        = "concurrency"
 	OptConnTimeout        = "connect-timeout"
 	OptChunkSize          = "chunk-size"

--- a/pkg/config/optnames.go
+++ b/pkg/config/optnames.go
@@ -12,7 +12,7 @@ const (
 	OptMetricsEndpoint             = "metrics-endpoint"
 
 	// Normal options with CLI arguments
-	OptAuthHeader         = "auth-header"
+	OptAuthToken          = "auth-token"
 	OptConcurrency        = "concurrency"
 	OptConnTimeout        = "connect-timeout"
 	OptChunkSize          = "chunk-size"


### PR DESCRIPTION
- **Revert "Rename --auth-token to --auth-header"**
- **Revert "Add --auth-token"**

This needs some rethinking. In most cases we shouldn't pass auth header if the original URL is redirected to an pre-signed URL. In that case some CDN will respond 400 or 403, plus we risk leaking the token.